### PR TITLE
Remove redundant patterns from coverage.exclude

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,12 +34,8 @@ export default defineConfig({
       exclude: [
         'src/components/ui/**',
         'src/vite-env.d.ts',
-        'config/**',
-        'sample-data/**',
-        'scripts/**',
         '**/*.test.ts',
         '**/*.test.tsx',
-        'tests/**',
       ],
       reporter: ['text', 'json', 'html'],
     },


### PR DESCRIPTION
This change cleans up the Vitest coverage configuration in `vite.config.ts` by removing redundant exclusion patterns for directories that are already outside the `include` scope.

Fixes #56

---
*PR created automatically by Jules for task [17618929769059805374](https://jules.google.com/task/17618929769059805374) started by @g1ddy*