### PR TITLE
Fix node reparenting logic to prevent visual drift and ensure correct detachment

### DIFF
--- a/src/features/visualization/components/DependencyGraph.drag.test.tsx
+++ b/src/features/visualization/components/DependencyGraph.drag.test.tsx
@@ -81,6 +81,8 @@ describe('DependencyGraph Drag Logic', () => {
     type: 'groupNode',
     position: { x: 0, y: 0 },
     positionAbsolute: { x: 0, y: 0 },
+    width: 200,
+    height: 200,
     data: {},
   } as Node;
   const featuresGroup = {
@@ -88,6 +90,8 @@ describe('DependencyGraph Drag Logic', () => {
     type: 'groupNode',
     position: { x: 10, y: 10 },
     positionAbsolute: { x: 10, y: 10 },
+    width: 150,
+    height: 150,
     data: {},
   } as Node;
 
@@ -124,8 +128,18 @@ describe('DependencyGraph Drag Logic', () => {
       parentId: 'src',
       position: { x: 50, y: 50 },
       positionAbsolute: { x: 50, y: 50 },
+      width: 50,
+      height: 20,
       data: { label: 'App.tsx' },
     } as Node;
+
+    // Update mock to return dragged node too
+    mockGetInternalNode.mockImplementation((id: string) => {
+        if (id === 'src') return srcGroup;
+        if (id === 'src/features') return featuresGroup;
+        if (id === 'node-1') return draggedNode;
+        return null;
+    });
 
     return { reparentNodeMock, draggedNode };
   };
@@ -151,5 +165,32 @@ describe('DependencyGraph Drag Logic', () => {
 
     // It should pick 'src/features'
     expect(reparentNodeMock).toHaveBeenCalledWith('node-1', 'src/features', expect.any(Object));
+  });
+
+  it('reparents to root (undefined) when dragged outside of all groups', () => {
+    const { reparentNodeMock, draggedNode } = setupDragTest([srcGroup]); // Originally intersecting src
+
+    // Move node far away
+    const movedNode = {
+      ...draggedNode,
+      positionAbsolute: { x: 500, y: 500 },
+    };
+
+    // Update mock to return new position for the dragged node
+    mockGetInternalNode.mockImplementation((id: string) => {
+        if (id === 'src') return srcGroup;
+        if (id === 'src/features') return featuresGroup;
+        if (id === 'node-1') return movedNode;
+        return null;
+    });
+
+    // Simulate React Flow still reporting intersection (React Flow might be loose or slow to update)
+    // BUT our geometry check should reject it.
+    mockGetIntersectingNodes.mockReturnValue([srcGroup]);
+
+    capturedReactFlowProps.onNodeDragStop!({} as React.MouseEvent, movedNode);
+
+    // Expect reparent to undefined
+    expect(reparentNodeMock).toHaveBeenCalledWith('node-1', undefined, expect.any(Object));
   });
 });

--- a/src/features/visualization/components/DependencyGraph.tsx
+++ b/src/features/visualization/components/DependencyGraph.tsx
@@ -10,6 +10,7 @@ import { CruiseResultSchema } from '@/schema/dependency-cruiser';
 import { AppNode } from './AppNode';
 import { GroupNode } from './GroupNode';
 import { type CustomNode, type AppNodeData } from '../types';
+import { isNodeCenterInside } from '../logic/geometry';
 
 const MINI_MAP_NODE_COLORS = {
   EXTERNAL: '#f59e0b', // amber-500
@@ -53,48 +54,58 @@ export function DependencyGraph() {
 
   const onNodeDragStop = useCallback(
     (_: React.MouseEvent, node: Node) => {
+      // Get the accurate position of the node (after drag)
+      const internalNode = getInternalNode(node.id);
+
+      // If we can't find the internal node, we can't reliably calculate geometry
+      if (!internalNode) return;
+
+      const nodeAbs = internalNode.positionAbsolute;
+      if (!nodeAbs) return;
+
       // Find intersecting nodes that are groups
       const intersections = getIntersectingNodes(node).filter(
         (n) => n.type === 'groupNode' && n.id !== node.id
       );
 
+      // Filter intersections based on geometry (Center Inside)
+      // We need to fetch the internal node for each group to get its dimensions/positionAbsolute
+      const validGroups = intersections.filter((group) => {
+        const internalGroup = getInternalNode(group.id);
+        if (!internalGroup) return false;
+        return isNodeCenterInside(internalNode, internalGroup);
+      });
+
       // Sort intersections to find the most specific group (deepest path/longest ID)
-      intersections.sort((a, b) => b.id.length - a.id.length);
+      validGroups.sort((a, b) => b.id.length - a.id.length);
 
-      const group = intersections[0] as CustomNode | undefined;
+      const targetGroup = validGroups[0] as CustomNode | undefined;
 
-      // Get the accurate position of the node (after drag)
-      // We rely on getInternalNode to ensure we have the latest positionAbsolute
-      // falling back to the passed node's positionAbsolute
-      // Use standard Node type but cast to CustomNode for legacy property access if needed,
-      // though internal nodes usually have positionAbsolute.
-      // We cast to CustomNode to satisfy TypeScript if the basic Node type is missing it in this version.
-      const internalNode = getInternalNode(node.id) as CustomNode | undefined;
-      const nodeAbs = internalNode?.positionAbsolute || (node as CustomNode).positionAbsolute;
-
-      // If dropped on a group
-      if (group) {
+      // If dropped on a valid group
+      if (targetGroup) {
         // Only update if parent is different
-        if (group.id !== node.parentId) {
-          // Get the most up-to-date absolute position of the group
-          const internalGroup = getInternalNode(group.id) as CustomNode | undefined;
-          const groupAbs = internalGroup?.positionAbsolute || group.positionAbsolute;
+        // We trigger this even if it's the SAME parent to correct the relative position
+        // if the store logic requires it, but usually we care about reparenting.
+        // However, if we drag inside the same parent, React Flow handles position updates.
+        // We only need to call reparentNode if the parent CHANGED.
+        if (targetGroup.id !== node.parentId) {
+          const internalGroup = getInternalNode(targetGroup.id) as CustomNode | undefined;
+          const groupAbs = internalGroup?.positionAbsolute || targetGroup.positionAbsolute;
 
-          if (nodeAbs && groupAbs) {
+          if (groupAbs) {
             const relativeX = nodeAbs.x - groupAbs.x;
             const relativeY = nodeAbs.y - groupAbs.y;
-            reparentNode(node.id, group.id, { x: relativeX, y: relativeY });
+            reparentNode(node.id, targetGroup.id, { x: relativeX, y: relativeY });
           }
         }
       } else {
-        // Dropped on canvas (no group)
+        // Dropped on canvas (no valid group found)
+        // If the node currently has a parent, it means we dragged it OUT.
         if (node.parentId) {
-          if (nodeAbs) {
-            reparentNode(node.id, undefined, {
-              x: nodeAbs.x,
-              y: nodeAbs.y,
-            });
-          }
+          reparentNode(node.id, undefined, {
+            x: nodeAbs.x,
+            y: nodeAbs.y,
+          });
         }
       }
     },

--- a/src/features/visualization/logic/geometry.test.ts
+++ b/src/features/visualization/logic/geometry.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { type Node } from '@xyflow/react';
+import { isNodeCenterInside } from './geometry';
+
+describe('isNodeCenterInside', () => {
+  const containerNode: Node = {
+    id: 'container',
+    position: { x: 0, y: 0 },
+    positionAbsolute: { x: 100, y: 100 },
+    width: 200,
+    height: 200,
+    data: {},
+  };
+
+  const createNode = (x: number, y: number, width = 50, height = 50): Node => ({
+    id: 'node',
+    position: { x: 0, y: 0 },
+    positionAbsolute: { x, y },
+    width,
+    height,
+    data: {},
+  });
+
+  it('returns true when node is fully inside container', () => {
+    // Container is at 100,100 with size 200x200 -> bounds: 100-300, 100-300
+    // Node at 150,150 with size 50x50 -> center at 175,175. Inside.
+    const node = createNode(150, 150);
+    expect(isNodeCenterInside(node, containerNode)).toBe(true);
+  });
+
+  it('returns true when node center is inside but edges stick out', () => {
+    // Node at 80,150 with size 50x50 -> center at 105,175.
+    // Container Left is 100. Center 105 is inside.
+    const node = createNode(80, 150);
+    expect(isNodeCenterInside(node, containerNode)).toBe(true);
+  });
+
+  it('returns false when node center is just outside container', () => {
+    // Node at 70,150 with size 50x50 -> center at 95,175.
+    // Container Left is 100. Center 95 is outside.
+    const node = createNode(70, 150);
+    expect(isNodeCenterInside(node, containerNode)).toBe(false);
+  });
+
+  it('returns false when node is fully outside', () => {
+    const node = createNode(400, 400);
+    expect(isNodeCenterInside(node, containerNode)).toBe(false);
+  });
+
+  it('handles nodes using measured dimensions', () => {
+    const measuredContainer: Node = {
+        ...containerNode,
+        width: undefined,
+        height: undefined,
+        measured: { width: 200, height: 200 },
+    };
+
+    const measuredNode: Node = {
+        ...createNode(150, 150),
+        width: undefined,
+        height: undefined,
+        measured: { width: 50, height: 50 },
+    };
+
+    expect(isNodeCenterInside(measuredNode, measuredContainer)).toBe(true);
+  });
+});

--- a/src/features/visualization/logic/geometry.ts
+++ b/src/features/visualization/logic/geometry.ts
@@ -1,0 +1,44 @@
+import { type Node } from '@xyflow/react';
+
+/**
+ * Checks if the center of the inner node is strictly inside the bounding box of the outer node.
+ *
+ * @param innerNode The node being dragged/checked (must have positionAbsolute and measured dimensions or width/height)
+ * @param outerNode The candidate container group (must have positionAbsolute and measured dimensions or width/height)
+ * @returns true if the center point of innerNode is within the rectangle of outerNode
+ */
+export function isNodeCenterInside(innerNode: Node, outerNode: Node): boolean {
+  // We need absolute positions for accurate comparison
+  const innerPos = innerNode.positionAbsolute || innerNode.position;
+  const outerPos = outerNode.positionAbsolute || outerNode.position;
+
+  if (!innerPos || !outerPos) {
+    return false;
+  }
+
+  // Get dimensions. React Flow uses 'measured' for actual rendered size,
+  // falling back to style or data if needed.
+  const innerWidth = innerNode.measured?.width ?? innerNode.width ?? (innerNode.style?.width as number) ?? 0;
+  const innerHeight = innerNode.measured?.height ?? innerNode.height ?? (innerNode.style?.height as number) ?? 0;
+
+  const outerWidth = outerNode.measured?.width ?? outerNode.width ?? (outerNode.style?.width as number) ?? 0;
+  const outerHeight = outerNode.measured?.height ?? outerNode.height ?? (outerNode.style?.height as number) ?? 0;
+
+  // Calculate center of the inner node
+  const innerCenterX = innerPos.x + innerWidth / 2;
+  const innerCenterY = innerPos.y + innerHeight / 2;
+
+  // Calculate bounds of the outer node
+  const outerLeft = outerPos.x;
+  const outerRight = outerPos.x + outerWidth;
+  const outerTop = outerPos.y;
+  const outerBottom = outerPos.y + outerHeight;
+
+  // Check containment
+  return (
+    innerCenterX >= outerLeft &&
+    innerCenterX <= outerRight &&
+    innerCenterY >= outerTop &&
+    innerCenterY <= outerBottom
+  );
+}


### PR DESCRIPTION
This PR fixes the issue where nodes would "drift" outside their parent containers or fail to detach when dragged out. 
It implements a stricter "Center Inside" geometry check to determine the target container (or lack thereof) during drag-and-drop operations, ensuring that nodes are only reparented if they are meaningfully dropped into a new group. 
It also ensures that dragging a node out of all groups correctly reparents it to the root level.

---
*PR created automatically by Jules for task [11906094057396023644](https://jules.google.com/task/11906094057396023644) started by @g1ddy*