### PR TITLE
💎 Refract: Use Position enum in XYFlow layout

### DIFF
--- a/src/features/visualization/logic/layout.ts
+++ b/src/features/visualization/logic/layout.ts
@@ -1,5 +1,5 @@
 import dagre from 'dagre';
-import { type Node, type Edge } from '@xyflow/react';
+import { type Node, type Edge, Position } from '@xyflow/react';
 
 // Default node dimensions if not yet measured
 const DEFAULT_NODE_WIDTH = 180;
@@ -131,15 +131,13 @@ export function applyDagreLayout(
         newStyle.height = height + GROUP_PADDING_BUFFER;
     }
 
-    const targetPosition = isHorizontal ? 'left' : 'top';
-    const sourcePosition = isHorizontal ? 'right' : 'bottom';
+    const targetPosition = isHorizontal ? Position.Left : Position.Top;
+    const sourcePosition = isHorizontal ? Position.Right : Position.Bottom;
 
     return {
       ...node,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
-      targetPosition: targetPosition as any,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
-      sourcePosition: sourcePosition as any,
+      targetPosition,
+      sourcePosition,
       position: {
         x,
         y,

--- a/src/schema/dependency-cruiser.ts
+++ b/src/schema/dependency-cruiser.ts
@@ -26,11 +26,11 @@ export const DependencySchema = z.object({
   /** Whether or not this is a dependency that can be followed any further */
   followable: z.boolean(),
   /** the instability of the dependency */
-  instability: z.number(),
+  instability: z.number().optional(),
   /** If the module specification is an URI with a protocol, this holds it */
-  protocol: z.enum(['data:', 'file:', 'node:']),
+  protocol: z.enum(['data:', 'file:', 'node:']).optional(),
   /** If the module specification is an URI and contains a mime type, this holds it */
-  mimeType: z.string(),
+  mimeType: z.string().optional(),
   /** The module system used (e.g., "es6", "cjs") */
   moduleSystem: z.enum(['amd', 'cjs', 'es6', 'tsd']),
   /** The import string used in the code (e.g., "./utils") */


### PR DESCRIPTION
🐛 Problem: Hardcoded layout positions were typed loosely as string literals requiring `as any` casts to bypass TypeScript and ESLint, and `DependencySchema` incorrectly threw validation errors on valid outputs where non-guaranteed fields were missing.
🛠️ Fix: Imported and used the React Flow `Position` enum instead, stripping `as any` and `eslint-disable` comments. Marked missing Dependency fields optional in `dependency-cruiser.ts`.
📉 Risk: Low.
🧪 Verification: Ran `pnpm tsc --noEmit && pnpm lint && pnpm test`, with tests fully verifying data loading.

---
*PR created automatically by Jules for task [7380084348870978953](https://jules.google.com/task/7380084348870978953) started by @g1ddy*