### PR TITLE
💎 Refract: [Layout Position Typings]

### DIFF
--- a/src/features/visualization/logic/layout.ts
+++ b/src/features/visualization/logic/layout.ts
@@ -1,5 +1,5 @@
 import dagre from 'dagre';
-import { type Node, type Edge } from '@xyflow/react';
+import { type Node, type Edge, Position } from '@xyflow/react';
 
 // Default node dimensions if not yet measured
 const DEFAULT_NODE_WIDTH = 180;
@@ -131,15 +131,13 @@ export function applyDagreLayout(
         newStyle.height = height + GROUP_PADDING_BUFFER;
     }
 
-    const targetPosition = isHorizontal ? 'left' : 'top';
-    const sourcePosition = isHorizontal ? 'right' : 'bottom';
+    const targetPosition = isHorizontal ? Position.Left : Position.Top;
+    const sourcePosition = isHorizontal ? Position.Right : Position.Bottom;
 
     return {
       ...node,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
-      targetPosition: targetPosition as any,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
-      sourcePosition: sourcePosition as any,
+      targetPosition,
+      sourcePosition,
       position: {
         x,
         y,


### PR DESCRIPTION
🐛 **Problem:** The dagre layout function (`src/features/visualization/logic/layout.ts`) was using hardcoded strings for target and source positions, bypassing TypeScript's safety via `eslint-disable` and `as any` casting.
🛠 **Fix:** Imported the `Position` enum from `@xyflow/react` and replaced the hardcoded strings with it. Removed the unsafe typing casts.
📉 **Risk:** Low. The change purely enforces strict static analysis without altering the functional output of the application.
🧪 **Verification:** Successfully executed `pnpm tsc --noEmit`, `pnpm lint`, and unit tests (`pnpm test`) without discovering any regressions.

---
*PR created automatically by Jules for task [12222426182005903126](https://jules.google.com/task/12222426182005903126) started by @g1ddy*