### PR TITLE
🎨 Palette: [UX improvement] Switch to ELK layout on mobile viewports

### DIFF
--- a/src/features/visualization/store.ts
+++ b/src/features/visualization/store.ts
@@ -31,6 +31,13 @@ export type ViewMode = 'standard' | 'instability';
 export type NodeSizeMode = 'uniform' | 'centrality';
 export type LayoutEngine = 'dagre' | 'elk';
 
+const getDefaultLayoutEngine = (): LayoutEngine => {
+  if (typeof window !== 'undefined' && window.matchMedia) {
+    return window.matchMedia('(max-width: 768px)').matches ? 'elk' : 'dagre';
+  }
+  return 'dagre';
+};
+
 interface GraphState {
   // React Flow State
   nodes: Node[];
@@ -230,7 +237,7 @@ export const useGraphStore = create<GraphState>()(
         rawComplexityMetrics: null,
         viewMode: 'standard',
         nodeSize: 'uniform',
-        layoutEngine: 'dagre',
+        layoutEngine: getDefaultLayoutEngine(),
         isolateModule: false,
 
         setInspectorOpen: (isOpen: boolean) => {
@@ -595,7 +602,7 @@ export const useGraphStore = create<GraphState>()(
         },
 
         reset: () => {
-          set({ nodes: [], edges: [], nodesById: new Map(), graph: null, originalGraph: null, hasUnsavedChanges: false, selectedNodeId: null, activeFilters: [], isInspectorOpen: false, rawComplexityMetrics: null, viewMode: 'standard', nodeSize: 'uniform', layoutEngine: 'dagre', isolateModule: false });
+          set({ nodes: [], edges: [], nodesById: new Map(), graph: null, originalGraph: null, hasUnsavedChanges: false, selectedNodeId: null, activeFilters: [], isInspectorOpen: false, rawComplexityMetrics: null, viewMode: 'standard', nodeSize: 'uniform', layoutEngine: getDefaultLayoutEngine(), isolateModule: false });
         },
 
         resetSimulation: () => {


### PR DESCRIPTION
This PR fixes Playwright test failures on Mobile Chrome viewports. The `dagre` layout was extending horizontally beyond the viewport, causing `locator.click()` timeouts because elements could not be fully scrolled into view.

By falling back to the `elk` layout engine for viewports `max-width: 768px`, the graph renders in a much more compact format, preventing out-of-bounds nodes and fixing all 9 mobile e2e tests. 

A `typeof window !== 'undefined'` guard ensures SSR compatibility.

---
*PR created automatically by Jules for task [2832610426522211221](https://jules.google.com/task/2832610426522211221) started by @g1ddy*