### PR TITLE
Fix persisted state overriding responsive layout default

### DIFF
--- a/src/features/visualization/store.test.ts
+++ b/src/features/visualization/store.test.ts
@@ -392,4 +392,105 @@ describe('Visualization Store', () => {
       expect(resetNode?.parentId).toBe('src');
     });
   });
+
+  describe('Layout Engine Persistence', () => {
+    it('should default layoutEngine based on viewport', () => {
+      // Mock mobile viewport
+      const matchMediaMock = vi.fn().mockImplementation(query => ({
+        matches: query === '(max-width: 768px)',
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+      }));
+      vi.stubGlobal('matchMedia', matchMediaMock);
+
+      useGraphStore.getState().reset();
+      expect(useGraphStore.getState().layoutEngine).toBe('elk');
+
+      // Mock desktop viewport
+      matchMediaMock.mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+      }));
+
+      useGraphStore.getState().reset();
+      expect(useGraphStore.getState().layoutEngine).toBe('dagre');
+
+      vi.unstubAllGlobals();
+    });
+
+    it('should update userSelectedLayoutEngine when setLayoutEngine is called', () => {
+      const store = useGraphStore.getState();
+      expect(store.userSelectedLayoutEngine).toBeNull();
+
+      store.setLayoutEngine('elk');
+      expect(useGraphStore.getState().userSelectedLayoutEngine).toBe('elk');
+      expect(useGraphStore.getState().layoutEngine).toBe('elk');
+
+      store.setLayoutEngine('dagre');
+      expect(useGraphStore.getState().userSelectedLayoutEngine).toBe('dagre');
+      expect(useGraphStore.getState().layoutEngine).toBe('dagre');
+    });
+
+    it('should reset userSelectedLayoutEngine on reset', () => {
+      const store = useGraphStore.getState();
+      store.setLayoutEngine('elk');
+      expect(useGraphStore.getState().userSelectedLayoutEngine).toBe('elk');
+
+      store.reset();
+      expect(useGraphStore.getState().userSelectedLayoutEngine).toBeNull();
+    });
+
+    it('should sync layoutEngine from userSelectedLayoutEngine during rehydration', () => {
+      // Access the persist configuration if possible, or just mock the storage
+      // Since we use createJSONStorage(() => robustStorage), and robustStorage uses localStorage if available.
+
+      const mockStorage: Record<string, string> = {
+        'dependency-graph-settings': JSON.stringify({
+          state: {
+            userSelectedLayoutEngine: 'elk',
+            viewMode: 'standard',
+            nodeSize: 'uniform',
+            hideTypeDefinitions: true,
+            layoutDirection: 'TB',
+            activeFilters: []
+          },
+          version: 0
+        })
+      };
+
+      vi.stubGlobal('localStorage', {
+        getItem: (key: string) => mockStorage[key] || null,
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+      });
+
+      // We need to re-create or re-initialize the store to trigger hydration,
+      // but useGraphStore is already created.
+      // Zustand's persist middleware usually hydrates on creation.
+
+      // Let's try to use the persist API if available
+      // useGraphStore.persist.rehydrate()
+
+      // But first, let's see if we can just check if it worked if we could trigger it.
+      // Actually, since it's a singleton, it might be hard to re-trigger without affecting other tests.
+
+      // Given the constraints, I will at least test the logic that would be used in onRehydrateStorage
+      // by asserting on the store state if I can trigger rehydration.
+
+      // Let's try to trigger rehydrate
+      void (useGraphStore as any).persist.rehydrate();
+
+      // Since rehydrate is async (though storage might be sync)
+      // we might need to wait.
+
+      expect(useGraphStore.getState().layoutEngine).toBe('elk');
+
+      vi.unstubAllGlobals();
+    });
+  });
 });

--- a/src/features/visualization/store.test.ts
+++ b/src/features/visualization/store.test.ts
@@ -396,7 +396,7 @@ describe('Visualization Store', () => {
   describe('Layout Engine Persistence', () => {
     it('should default layoutEngine based on viewport', () => {
       // Mock mobile viewport
-      const matchMediaMock = vi.fn().mockImplementation(query => ({
+      const matchMediaMock = vi.fn().mockImplementation((query: string) => ({
         matches: query === '(max-width: 768px)',
         media: query,
         onchange: null,
@@ -409,7 +409,7 @@ describe('Visualization Store', () => {
       expect(useGraphStore.getState().layoutEngine).toBe('elk');
 
       // Mock desktop viewport
-      matchMediaMock.mockImplementation(query => ({
+      matchMediaMock.mockImplementation((query: string) => ({
         matches: false,
         media: query,
         onchange: null,
@@ -445,7 +445,7 @@ describe('Visualization Store', () => {
       expect(useGraphStore.getState().userSelectedLayoutEngine).toBeNull();
     });
 
-    it('should sync layoutEngine from userSelectedLayoutEngine during rehydration', () => {
+    it('should sync layoutEngine from userSelectedLayoutEngine during rehydration', async () => {
       // Access the persist configuration if possible, or just mock the storage
       // Since we use createJSONStorage(() => robustStorage), and robustStorage uses localStorage if available.
 
@@ -483,7 +483,10 @@ describe('Visualization Store', () => {
       // by asserting on the store state if I can trigger rehydration.
 
       // Let's try to trigger rehydrate
-      void (useGraphStore as any).persist.rehydrate();
+      const storeWithPersist = useGraphStore as typeof useGraphStore & {
+        persist: { rehydrate: () => Promise<void> };
+      };
+      await storeWithPersist.persist.rehydrate();
 
       // Since rehydrate is async (though storage might be sync)
       // we might need to wait.

--- a/src/features/visualization/store.ts
+++ b/src/features/visualization/store.ts
@@ -63,6 +63,7 @@ interface GraphState {
   viewMode: ViewMode;
   nodeSize: NodeSizeMode;
   layoutEngine: LayoutEngine;
+  userSelectedLayoutEngine: LayoutEngine | null;
   isolateModule: boolean;
 
   // Actions
@@ -238,6 +239,7 @@ export const useGraphStore = create<GraphState>()(
         viewMode: 'standard',
         nodeSize: 'uniform',
         layoutEngine: getDefaultLayoutEngine(),
+        userSelectedLayoutEngine: null,
         isolateModule: false,
 
         setInspectorOpen: (isOpen: boolean) => {
@@ -253,7 +255,7 @@ export const useGraphStore = create<GraphState>()(
         },
 
         setLayoutEngine: (engine: LayoutEngine) => {
-          set({ layoutEngine: engine });
+          set({ layoutEngine: engine, userSelectedLayoutEngine: engine });
           // Trigger re-layout
           void get().layoutGraph();
         },
@@ -602,7 +604,7 @@ export const useGraphStore = create<GraphState>()(
         },
 
         reset: () => {
-          set({ nodes: [], edges: [], nodesById: new Map(), graph: null, originalGraph: null, hasUnsavedChanges: false, selectedNodeId: null, activeFilters: [], isInspectorOpen: false, rawComplexityMetrics: null, viewMode: 'standard', nodeSize: 'uniform', layoutEngine: getDefaultLayoutEngine(), isolateModule: false });
+          set({ nodes: [], edges: [], nodesById: new Map(), graph: null, originalGraph: null, hasUnsavedChanges: false, selectedNodeId: null, activeFilters: [], isInspectorOpen: false, rawComplexityMetrics: null, viewMode: 'standard', nodeSize: 'uniform', layoutEngine: getDefaultLayoutEngine(), userSelectedLayoutEngine: null, isolateModule: false });
         },
 
         resetSimulation: () => {
@@ -644,13 +646,20 @@ export const useGraphStore = create<GraphState>()(
       name: 'dependency-graph-settings',
       storage: createJSONStorage(() => robustStorage),
       partialize: (state) => ({
-        layoutEngine: state.layoutEngine,
+        userSelectedLayoutEngine: state.userSelectedLayoutEngine,
         viewMode: state.viewMode,
         nodeSize: state.nodeSize,
         hideTypeDefinitions: state.hideTypeDefinitions,
         layoutDirection: state.layoutDirection,
         activeFilters: state.activeFilters,
       }),
+      onRehydrateStorage: () => {
+        return (rehydratedState) => {
+          if (rehydratedState?.userSelectedLayoutEngine) {
+            rehydratedState.layoutEngine = rehydratedState.userSelectedLayoutEngine;
+          }
+        };
+      },
     }
   )
 );

--- a/src/features/visualization/store.ts
+++ b/src/features/visualization/store.ts
@@ -655,8 +655,8 @@ export const useGraphStore = create<GraphState>()(
       }),
       onRehydrateStorage: () => {
         return (rehydratedState) => {
-          if (rehydratedState?.userSelectedLayoutEngine) {
-            rehydratedState.layoutEngine = rehydratedState.userSelectedLayoutEngine;
+          if (rehydratedState) {
+            rehydratedState.layoutEngine = rehydratedState.userSelectedLayoutEngine ?? getDefaultLayoutEngine();
           }
         };
       },

--- a/src/features/visualization/store.ts
+++ b/src/features/visualization/store.ts
@@ -653,11 +653,12 @@ export const useGraphStore = create<GraphState>()(
         layoutDirection: state.layoutDirection,
         activeFilters: state.activeFilters,
       }),
-      onRehydrateStorage: () => {
-        return (rehydratedState) => {
-          if (rehydratedState) {
-            rehydratedState.layoutEngine = rehydratedState.userSelectedLayoutEngine ?? getDefaultLayoutEngine();
-          }
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as Partial<GraphState> | undefined;
+        return {
+          ...currentState,
+          ...persisted,
+          layoutEngine: persisted?.userSelectedLayoutEngine ?? currentState.layoutEngine,
         };
       },
     }


### PR DESCRIPTION
Resolved an issue where the persisted layout engine would override the responsive default (e.g., 'elk' for mobile, 'dagre' for desktop) when a user switched devices or resized their browser.

By introducing a `userSelectedLayoutEngine` state, we now distinguish between the algorithm currently in use and the one explicitly chosen by the user. The active `layoutEngine` defaults to a viewport-responsive value on every load, and is only overridden if a `userSelectedLayoutEngine` preference is found in local storage during hydration.

Key changes:
- Modified `GraphState` and store actions in `src/features/visualization/store.ts` to manage the new state.
- Refactored `persist` middleware to handle conditional rehydration.
- Added comprehensive unit tests in `src/features/visualization/store.test.ts`.
- Verified the fix with Playwright screenshots for both desktop and mobile viewports.

Fixes #183

---
*PR created automatically by Jules for task [5194868703446085045](https://jules.google.com/task/5194868703446085045) started by @g1ddy*