### PR TITLE
Fix node attribute merging in relationship data processing

### DIFF
--- a/src/features/relationships/store.test.ts
+++ b/src/features/relationships/store.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useRelationshipStore } from './store';
+import type { CsvRow } from './types';
+
+describe('useRelationshipStore', () => {
+  beforeEach(() => {
+    useRelationshipStore.getState().reset();
+  });
+
+  it('should correctly merge node attributes when a node appears as both source and target', () => {
+    const csvData: CsvRow[] = [
+      {
+        Source: 'NodeA',
+        Target: 'NodeB',
+        Target_Role: 'SpecificRole',
+        Target_Domain: 'SpecificDomain',
+        Relationship: 'Rel1',
+        Relationship_Type: 'Type1',
+        Relationship_Weight: '1',
+        Reference_Type: 'Ref1',
+        Reference_Context: 'Ctx1'
+      },
+      {
+        Source: 'NodeB',
+        Target: 'NodeC',
+        Target_Role: 'AnotherRole',
+        Target_Domain: 'AnotherDomain',
+        Relationship: 'Rel2',
+        Relationship_Type: 'Type2',
+        Relationship_Weight: '1',
+        Reference_Type: 'Ref2',
+        Reference_Context: 'Ctx2'
+      }
+    ];
+
+    useRelationshipStore.getState().setData(csvData);
+
+    const nodesById = useRelationshipStore.getState().nodesById;
+    const nodeB = nodesById.get('NodeB');
+
+    expect(nodeB).toBeDefined();
+    // NodeB appears as Target in the first row, so it should have SpecificRole and SpecificDomain
+    expect(nodeB?.role).toBe('SpecificRole');
+    expect(nodeB?.cluster).toBe('SpecificDomain');
+  });
+
+  it('should prioritize Target attributes even if Source appears first', () => {
+    const csvData: CsvRow[] = [
+      {
+        Source: 'NodeB',
+        Target: 'NodeC',
+        Target_Role: 'AnotherRole',
+        Target_Domain: 'AnotherDomain',
+        Relationship: 'Rel2',
+        Relationship_Type: 'Type2',
+        Relationship_Weight: '1',
+        Reference_Type: 'Ref2',
+        Reference_Context: 'Ctx2'
+      },
+      {
+        Source: 'NodeA',
+        Target: 'NodeB',
+        Target_Role: 'SpecificRole',
+        Target_Domain: 'SpecificDomain',
+        Relationship: 'Rel1',
+        Relationship_Type: 'Type1',
+        Relationship_Weight: '1',
+        Reference_Type: 'Ref1',
+        Reference_Context: 'Ctx1'
+      }
+    ];
+
+    useRelationshipStore.getState().setData(csvData);
+
+    const nodesById = useRelationshipStore.getState().nodesById;
+    const nodeB = nodesById.get('NodeB');
+
+    expect(nodeB).toBeDefined();
+    // Even though NodeB appeared as Source first (getting default 'Source' attributes),
+    // it should be updated with 'SpecificRole' and 'SpecificDomain' when it appears as Target.
+    expect(nodeB?.role).toBe('SpecificRole');
+    expect(nodeB?.cluster).toBe('SpecificDomain');
+  });
+
+  it('should upgrade from Source to Target even if no specific attributes are provided', () => {
+    const csvData: CsvRow[] = [
+      {
+        Source: 'NodeB',
+        Target: 'NodeC',
+        Target_Role: '',
+        Target_Domain: '',
+        Relationship: 'Rel2',
+        Relationship_Type: 'Type2',
+        Relationship_Weight: '1',
+        Reference_Type: 'Ref2',
+        Reference_Context: 'Ctx2'
+      },
+      {
+        Source: 'NodeA',
+        Target: 'NodeB',
+        Target_Role: '',
+        Target_Domain: '',
+        Relationship: 'Rel1',
+        Relationship_Type: 'Type1',
+        Relationship_Weight: '1',
+        Reference_Type: 'Ref1',
+        Reference_Context: 'Ctx1'
+      }
+    ];
+
+    useRelationshipStore.getState().setData(csvData);
+
+    const nodesById = useRelationshipStore.getState().nodesById;
+    const nodeB = nodesById.get('NodeB');
+
+    expect(nodeB).toBeDefined();
+    // NodeB should be upgraded to 'Target' / 'Unspecified'
+    expect(nodeB?.role).toBe('Target');
+    expect(nodeB?.cluster).toBe('Unspecified');
+  });
+
+  it('should handle providing only domain when upgrading from Source', () => {
+    const csvData: CsvRow[] = [
+      {
+        Source: 'NodeB',
+        Target: 'NodeC',
+        Target_Role: '',
+        Target_Domain: '',
+        Relationship: 'Rel2',
+        Relationship_Type: 'Type2',
+        Relationship_Weight: '1',
+        Reference_Type: 'Ref2',
+        Reference_Context: 'Ctx2'
+      },
+      {
+        Source: 'NodeA',
+        Target: 'NodeB',
+        Target_Role: '',
+        Target_Domain: 'NewDomain',
+        Relationship: 'Rel1',
+        Relationship_Type: 'Type1',
+        Relationship_Weight: '1',
+        Reference_Type: 'Ref1',
+        Reference_Context: 'Ctx1'
+      }
+    ];
+
+    useRelationshipStore.getState().setData(csvData);
+
+    const nodesById = useRelationshipStore.getState().nodesById;
+    const nodeB = nodesById.get('NodeB');
+
+    expect(nodeB).toBeDefined();
+    expect(nodeB?.role).toBe('Target');
+    expect(nodeB?.cluster).toBe('NewDomain');
+  });
+});

--- a/src/features/relationships/store.ts
+++ b/src/features/relationships/store.ts
@@ -37,10 +37,17 @@ export const useRelationshipStore = create<RelationshipState>((set) => ({
 
       // Target Node
       const existingTarget = nodesMap.get(row.Target);
+
+      const role = row.Target_Role ||
+                   (existingTarget && existingTarget.role !== 'Source' ? existingTarget.role : 'Target');
+
+      const cluster = row.Target_Domain ||
+                      (existingTarget && existingTarget.cluster !== 'Source' ? existingTarget.cluster : 'Unspecified');
+
       nodesMap.set(row.Target, {
         id: row.Target,
-        role: row.Target_Role || (existingTarget && existingTarget.role !== 'Source' ? existingTarget.role : 'Target'),
-        cluster: row.Target_Domain || (existingTarget && existingTarget.cluster !== 'Source' ? existingTarget.cluster : 'Unspecified'),
+        role,
+        cluster,
         degree: existingTarget?.degree ?? 0
       });
 

--- a/src/features/relationships/store.ts
+++ b/src/features/relationships/store.ts
@@ -36,14 +36,13 @@ export const useRelationshipStore = create<RelationshipState>((set) => ({
       }
 
       // Target Node
-      if (!nodesMap.has(row.Target)) {
-        nodesMap.set(row.Target, {
-            id: row.Target,
-          role: row.Target_Role || 'Target',
-          cluster: row.Target_Domain || 'Unspecified',
-            degree: 0
-        });
-      }
+      const existingTarget = nodesMap.get(row.Target);
+      nodesMap.set(row.Target, {
+        id: row.Target,
+        role: row.Target_Role || (existingTarget && existingTarget.role !== 'Source' ? existingTarget.role : 'Target'),
+        cluster: row.Target_Domain || (existingTarget && existingTarget.cluster !== 'Source' ? existingTarget.cluster : 'Unspecified'),
+        degree: existingTarget?.degree ?? 0
+      });
 
       // Link
       links.push({


### PR DESCRIPTION
This PR fixes a bug in the relationship data processing logic where node attributes (Role and Domain) were dependent on the order of rows in the CSV. Specifically, if a node appeared as a Source first, it would get default placeholder attributes ('Source', 'Source') and would not be updated even if more specific Target_Role or Target_Domain information was available in later rows where the node appeared as a Target.

The fix ensures that nodes are always 'upgraded' from their initial placeholder state when encountered as a Target, and that more specific information always takes precedence.

Key changes:
- Refined `setData` logic in `src/features/relationships/store.ts`.
- Added comprehensive unit tests in `src/features/relationships/store.test.ts`.
- Verified the fix visually with a Playwright script and screenshot.

Fixes #106

---
*PR created automatically by Jules for task [8263898009677559475](https://jules.google.com/task/8263898009677559475) started by @g1ddy*