### PR TITLE
💎 Refract: Improve type safety in CruiseResultSchema

### DIFF
--- a/src/schema/dependency-cruiser.ts
+++ b/src/schema/dependency-cruiser.ts
@@ -99,6 +99,6 @@ export const CruiseResultSchema = z.object({
     totalDependenciesCruised: z.number().optional(),
     violations: z.array(ViolationSchema),
     warn: z.number(),
-    optionsUsed: z.any(),
+    optionsUsed: z.unknown(),
   }).passthrough(),
 }).passthrough();


### PR DESCRIPTION
🐛 Problem: The `CruiseResultSchema` in `src/schema/dependency-cruiser.ts` used `z.any()` for the `optionsUsed` property. Using `any` bypasses type checking and can lead to unexpected runtime errors if the property is misused downstream.
🛠 Fix: Replaced `z.any()` with `z.unknown()` for the `optionsUsed` property to enforce type-narrowing before access, aligning with TypeScript and Zod best practices for safer type hygiene.
📉 Risk: Low. The change is isolated to the schema definition and only enforces safer access without changing runtime behavior.
🧪 Verification: Ran `pnpm tsc --noEmit` and confirmed no type errors were introduced. Also ran `pnpm test` and `pnpm lint`, ensuring schema tests and general codebase integrity remain intact.

---
*PR created automatically by Jules for task [16534469413841037714](https://jules.google.com/task/16534469413841037714) started by @g1ddy*