### PR TITLE
💎 Refract: Enforce CLI contract and portable ESLint API

### DIFF
--- a/src/cli/analyze/adapters.test.ts
+++ b/src/cli/analyze/adapters.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import { readDependencyGraph, runEslintComplexityScan } from './adapters';
+import { ValidationError } from './models';
+import { ESLint } from 'eslint';
+
+vi.mock('fs/promises', () => ({
+    readFile: vi.fn(),
+    mkdir: vi.fn(),
+    writeFile: vi.fn()
+}));
+
+vi.mock('eslint', () => {
+    return {
+        ESLint: vi.fn()
+    };
+});
+
+describe('adapters', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('readDependencyGraph', () => {
+        it('should return modules for valid JSON and schema', async () => {
+            const validData = {
+                modules: [{ source: 'src/a.ts', valid: true, dependencies: [], dependents: [] }],
+                summary: { error: 0, ignore: 0, info: 0, totalCruised: 1, violations: [], warn: 0, optionsUsed: {} }
+            };
+            vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(validData));
+
+            const result = await readDependencyGraph('dummy.json');
+            expect(result).toHaveLength(1);
+            expect(result[0].source).toBe('src/a.ts');
+        });
+
+        it('should throw Error if file cannot be read', async () => {
+            vi.mocked(fs.readFile).mockRejectedValue(new Error('ENOENT'));
+            await expect(readDependencyGraph('dummy.json')).rejects.toThrow('Failed to read dependency graph');
+        });
+
+        it('should throw ValidationError if JSON is malformed', async () => {
+            vi.mocked(fs.readFile).mockResolvedValue('invalid json {');
+            await expect(readDependencyGraph('dummy.json')).rejects.toThrow(ValidationError);
+        });
+
+        it('should throw ValidationError if schema is invalid', async () => {
+            const invalidData = {
+                modules: 'not an array'
+            };
+            vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(invalidData));
+            await expect(readDependencyGraph('dummy.json')).rejects.toThrow(ValidationError);
+        });
+    });
+
+    describe('runEslintComplexityScan', () => {
+        it('should return mapped results on success', async () => {
+            const mockResults = [{
+                filePath: 'src/a.ts',
+                messages: [{ ruleId: 'complexity', message: 'Too complex' }]
+            }];
+
+            vi.mocked(ESLint).mockImplementation(function() {
+                return {
+                    lintFiles: vi.fn().mockResolvedValue(mockResults)
+                } as unknown as ESLint;
+            });
+
+            const result = await runEslintComplexityScan('src');
+            expect(result).toHaveLength(1);
+            expect(result[0].filePath).toBe('src/a.ts');
+            expect(result[0].messages[0].ruleId).toBe('complexity');
+        });
+
+        it('should throw Error if linting fails', async () => {
+            vi.mocked(ESLint).mockImplementation(function() {
+                return {
+                    lintFiles: vi.fn().mockRejectedValue(new Error('Failed execution'))
+                } as unknown as ESLint;
+            });
+
+            await expect(runEslintComplexityScan('src')).rejects.toThrow('Failed to run ESLint: Failed execution');
+        });
+    });
+});

--- a/src/cli/analyze/adapters.ts
+++ b/src/cli/analyze/adapters.ts
@@ -1,53 +1,67 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { execFileSync } from 'child_process';
-import type { DependencyCruiserModule, EslintResult } from './models';
+import { ESLint } from 'eslint';
+import { CruiseResultSchema } from '../../schema/dependency-cruiser';
+import { ValidationError, type DependencyCruiserModule, type EslintResult } from './models';
 
 export async function readDependencyGraph(graphPath: string): Promise<DependencyCruiserModule[]> {
+    const absolutePath = path.resolve(process.cwd(), graphPath);
+    let data: string;
+    let parsed: unknown;
+
     try {
-        const absolutePath = path.resolve(process.cwd(), graphPath);
-        const data = await fs.readFile(absolutePath, 'utf8');
-        const parsed = JSON.parse(data) as { modules?: DependencyCruiserModule[] };
-        return parsed.modules || [];
+        data = await fs.readFile(absolutePath, 'utf8');
     } catch (e: unknown) {
         const message = e instanceof Error ? e.message : String(e);
-        throw new Error(`Failed to read or parse dependency graph at ${graphPath}: ${message}`);
+        throw new Error(`Failed to read dependency graph at ${graphPath}: ${message}`);
     }
+
+    try {
+        parsed = JSON.parse(data);
+    } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : String(e);
+        throw new ValidationError(`Invalid JSON in dependency graph at ${graphPath}: ${message}`);
+    }
+
+    const validationResult = CruiseResultSchema.safeParse(parsed);
+
+    if (!validationResult.success) {
+        throw new ValidationError(`Invalid dependency-cruiser output shape in ${graphPath}:\n${validationResult.error.message}`);
+    }
+
+    // Return using the validated structure, picking only what we need
+    return validationResult.data.modules.map(m => ({
+        source: m.source,
+        dependencies: m.dependencies,
+        dependents: m.dependents
+    }));
 }
 
-export function runEslintComplexityScan(sourcePath: string): EslintResult[] {
+export async function runEslintComplexityScan(sourcePath: string): Promise<EslintResult[]> {
     try {
         // Replace backslashes with forward slashes for cross-platform compatibility with globbing
         const target = path.resolve(process.cwd(), sourcePath).replace(/\\/g, '/');
         const globPattern = `${target}/**/*.{ts,tsx}`;
 
-        const output = execFileSync('npx', [
-            '--no-install',
-            'eslint',
-            globPattern,
-            '--format', 'json',
-            '--rule', 'complexity: ["warn", 0]',
-            '--parser', '@typescript-eslint/parser'
-        ], {
-            encoding: 'utf8',
-            maxBuffer: 10 * 1024 * 1024,
-            stdio: ['ignore', 'pipe', 'pipe']
+        const eslint = new ESLint({
+            overrideConfig: [{
+                rules: {
+                    'complexity': ['warn', 0]
+                }
+            }]
         });
 
-        return JSON.parse(output) as EslintResult[];
-    } catch (e: unknown) {
-        // ESLint returns exit code 1 if there are warnings (which we expect for complexity > 0)
-        const execError = e as { stdout?: Buffer | string; message?: string };
-        if (execError.stdout) {
-            try {
-                const stdoutStr = typeof execError.stdout === 'string' ? execError.stdout : execError.stdout.toString('utf8');
-                return JSON.parse(stdoutStr) as EslintResult[];
-            } catch {
-                 const stdoutStr = typeof execError.stdout === 'string' ? execError.stdout : execError.stdout.toString('utf8');
-                 throw new Error(`Failed to parse ESLint output: ${stdoutStr.substring(0, 200)}...`);
-            }
-        }
+        const results = await eslint.lintFiles([globPattern]);
 
+        // Map ESLint's API results to the EslintResult interface we defined
+        return results.map(result => ({
+            filePath: result.filePath,
+            messages: result.messages.map(msg => ({
+                ruleId: msg.ruleId || 'unknown',
+                message: msg.message
+            }))
+        }));
+    } catch (e: unknown) {
         const message = e instanceof Error ? e.message : String(e);
         throw new Error(`Failed to run ESLint: ${message}`);
     }

--- a/src/cli/analyze/models.ts
+++ b/src/cli/analyze/models.ts
@@ -38,3 +38,10 @@ export interface DependencyCruiserModule {
     dependencies: unknown[];
     dependents: unknown[];
 }
+
+export class ValidationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ValidationError';
+    }
+}

--- a/src/cli/commands/analyze.test.ts
+++ b/src/cli/commands/analyze.test.ts
@@ -11,7 +11,7 @@ describe('runAnalyzeCommand', () => {
             { source: 'src/a.ts', dependencies: [], dependents: [] }
         ]);
 
-        vi.spyOn(adapters, 'runEslintComplexityScan').mockReturnValue([]);
+        vi.spyOn(adapters, 'runEslintComplexityScan').mockResolvedValue([]);
         vi.spyOn(adapters, 'countLinesOfCode').mockResolvedValue({ 'src/a.ts': 100 });
         vi.spyOn(adapters, 'writeOutputFiles').mockResolvedValue(undefined);
     });
@@ -26,9 +26,9 @@ describe('runAnalyzeCommand', () => {
         expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Usage: maritime analyze'));
     });
 
-    it('should return 1 if missing required arguments', async () => {
+    it('should return 2 if missing required arguments', async () => {
         const exitCode = await runAnalyzeCommand(['--source', 'src']);
-        expect(exitCode).toBe(1);
+        expect(exitCode).toBe(2);
         expect(console.error).toHaveBeenCalledWith(expect.stringContaining('are required'));
     });
 

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -8,7 +8,7 @@ import {
 import { calculateMetrics } from '../analyze/calculate-metrics';
 import { parseEslintComplexityReport } from '../analyze/parse-eslint';
 import { renderMarkdownReport } from '../analyze/render-markdown-report';
-import type { AnalysisThresholds } from '../analyze/models';
+import { ValidationError, type AnalysisThresholds } from '../analyze/models';
 import * as path from 'path';
 
 const DEFAULT_THRESHOLDS: AnalysisThresholds = {
@@ -18,8 +18,16 @@ const DEFAULT_THRESHOLDS: AnalysisThresholds = {
 };
 
 export async function runAnalyzeCommand(args: string[]): Promise<number> {
+    let values: {
+        source?: string;
+        graph?: string;
+        metrics?: string;
+        report?: string;
+        help?: boolean;
+    };
+
     try {
-        const { values } = parseArgs({
+        const parsed = parseArgs({
             args,
             allowPositionals: true,
             options: {
@@ -30,24 +38,39 @@ export async function runAnalyzeCommand(args: string[]): Promise<number> {
                 help: { type: 'boolean', short: 'h' }
             }
         });
+        values = parsed.values;
+    } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : String(e);
+        console.error(`Error parsing arguments: ${message}`);
+        return 2;
+    }
 
-        if (values.help) {
-            console.log(`
-Usage: maritime analyze [options]
+    if (values.help) {
+        console.log(`
+Usage: maritime analyze --graph <file> --metrics <file> --report <file> [--source <dir>]
 
 Options:
-  --source <dir>     Source directory to analyze (default: "src")
   --graph <file>     Input dependency-cruiser JSON
   --metrics <file>   Output JSON file for metrics
   --report <file>    Output Markdown file for the report
-            `);
-            return 0;
-        }
+  --source <dir>     Source directory to analyze (default: "src")
 
-        if (!values.graph || !values.metrics || !values.report) {
-            console.error('Error: --graph, --metrics, and --report are required for analyze command.');
-            return 1;
-        }
+Note: analyze consumes a dependency graph; it does not generate one.
+
+Exit Codes:
+  0 - Successful analysis
+  1 - Operational or runtime failure
+  2 - Invalid CLI arguments or invalid input artifact/schema
+        `);
+        return 0;
+    }
+
+    if (!values.graph || !values.metrics || !values.report) {
+        console.error('Error: --graph, --metrics, and --report are required.');
+        return 2;
+    }
+
+    try {
 
         console.log('📊 Starting Complexity Analysis...');
 
@@ -55,12 +78,13 @@ Options:
         console.log('   - Reading Dependency Cruiser JSON...');
         const modules = await readDependencyGraph(values.graph);
 
+        const rawSource = values.source || 'src';
+
         // 2. ESLint for complexity
         console.log('   - Running ESLint for Complexity...');
-        const eslintResults = runEslintComplexityScan(values.source);
+        const eslintResults = await runEslintComplexityScan(rawSource);
         const complexityMap = parseEslintComplexityReport(eslintResults, process.cwd());
 
-        const rawSource = values.source || 'src';
         // Convert to a repo-relative path, replacing backslashes with forward slashes
         // This handles absolute paths, './src', 'src/', etc., cleanly relative to cwd
         let normalizedSource = path.relative(process.cwd(), path.resolve(process.cwd(), rawSource)).replace(/\\/g, '/');
@@ -117,6 +141,10 @@ Options:
     } catch (e: unknown) {
         const message = e instanceof Error ? e.message : String(e);
         console.error(`Error analyzing project: ${message}`);
+
+        if (e instanceof ValidationError) {
+            return 2;
+        }
         return 1;
     }
 }


### PR DESCRIPTION
🐛 Problem:
1. The `maritime analyze` CLI accepted malformed or wrong dependency-cruiser graphs without validation, potentially producing falsely healthy reports.
2. The ESLint complexity scan relied on an `npx eslint` shell execution which is brittle, non-portable (e.g. issues on Windows with shell interpolation), and fails if warnings are encountered.
3. The CLI lacked a strict contract for required parameters and specific exit codes to distinguish input validation vs runtime failures.

🛠️ Fix:
1. Validated the JSON input using `CruiseResultSchema.safeParse` in `readDependencyGraph`. Invalid schema shapes now throw a `ValidationError` which exits with code 2.
2. Migrated `runEslintComplexityScan` to an `async` function utilizing the `ESLint` Node API. This respects the consumer's configuration while overriding only the complexity rule, treating findings as data.
3. Overhauled argument parsing in `runAnalyzeCommand` to manually catch `parseArgs` errors, enforcing required arguments (`--graph`, `--metrics`, `--report`) and exiting with code 2. Documented these exit codes in `--help`.

📉 Risk:
Low. These changes are localized to the headless CLI/analysis boundary (`src/cli`), having zero impact on the React UI. The ESLint migration correctly falls back on local configs.

🧪 Verification:
- All unit tests updated and passing (`vitest`).
- Build succeeds (`npm run build`).
- Linter passes clean (`npm run lint`).
- Manual `maritime analyze --help` verified output and contract documentation.

---
*PR created automatically by Jules for task [9644403324898707287](https://jules.google.com/task/9644403324898707287) started by @g1ddy*