### PR TITLE
💎 Refract: [Remove any type from ReactFlow mock]

### DIFF
--- a/src/features/visualization/components/DependencyGraph.drag.test.tsx
+++ b/src/features/visualization/components/DependencyGraph.drag.test.tsx
@@ -24,11 +24,8 @@ vi.mock('@xyflow/react', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@xyflow/react')>();
   return {
     ...actual,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ReactFlow: (props: any) => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    ReactFlow: (props: ReactFlowMockProps) => {
       capturedReactFlowProps = props;
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       return <div className="react-flow-mock">{props.children}</div>;
     },
     useReactFlow: () => ({


### PR DESCRIPTION
🐛 Problem: The `ReactFlow` mock in `src/features/visualization/components/DependencyGraph.drag.test.tsx` used the `any` type for props (`props: any`), violating the strict TypeScript hygiene rule and causing unnecessary ESLint suppressions.
🛠️ Fix: Converted the `any` type to the explicitly defined `ReactFlowMockProps` interface which was already available in the file.
📉 Risk: Low
🧪 Verification: Ran `pnpm tsc --noEmit` and `pnpm lint` and `pnpm test` to verify no type or test regressions.

---
*PR created automatically by Jules for task [1240105113240500480](https://jules.google.com/task/1240105113240500480) started by @g1ddy*