### PR TITLE
Enforce modern ESLint flat config and Node runtime baseline

### DIFF
--- a/src/cli/analyze/adapters.test.ts
+++ b/src/cli/analyze/adapters.test.ts
@@ -62,6 +62,7 @@ describe('adapters', () => {
 
             vi.mocked(ESLint).mockImplementation(function() {
                 return {
+                    isPathIgnored: vi.fn().mockResolvedValue(false),
                     lintFiles: vi.fn().mockResolvedValue(mockResults)
                 } as unknown as ESLint;
             });
@@ -72,9 +73,23 @@ describe('adapters', () => {
             expect(result[0].messages[0].ruleId).toBe('complexity');
         });
 
+        it('should identify ignored files when isPathIgnored returns true', async () => {
+            vi.mocked(ESLint).mockImplementation(function() {
+                return {
+                    isPathIgnored: vi.fn().mockResolvedValue(true),
+                    lintFiles: vi.fn().mockResolvedValue([])
+                } as unknown as ESLint;
+            });
+
+            const result = await runEslintComplexityScan('src', ['build/sites-vite-plugin.ts']);
+            expect(result).toHaveLength(1);
+            expect(result[0].ignored).toBe(true);
+        });
+
         it('should throw Error if linting fails', async () => {
             vi.mocked(ESLint).mockImplementation(function() {
                 return {
+                    isPathIgnored: vi.fn().mockResolvedValue(false),
                     lintFiles: vi.fn().mockRejectedValue(new Error('Failed execution'))
                 } as unknown as ESLint;
             });

--- a/src/cli/analyze/adapters.ts
+++ b/src/cli/analyze/adapters.ts
@@ -4,22 +4,25 @@ import { ESLint } from 'eslint';
 import { CruiseResultSchema } from '../../schema/dependency-cruiser';
 import { ValidationError, type DependencyCruiserModule, type EslintResult } from './models';
 
-export async function readDependencyGraph(graphPath: string): Promise<DependencyCruiserModule[]> {
-    const absolutePath = path.resolve(process.cwd(), graphPath);
+export async function readDependencyGraph(
+    graphPath: string,
+    cwd: string = process.cwd()
+): Promise<DependencyCruiserModule[]> {
+    const absolutePath = path.resolve(cwd, graphPath);
     let data: string;
     let parsed: unknown;
 
     try {
         data = await fs.readFile(absolutePath, 'utf8');
-    } catch (e: unknown) {
-        const message = e instanceof Error ? e.message : String(e);
+    } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
         throw new Error(`Failed to read dependency graph at ${graphPath}: ${message}`);
     }
 
     try {
         parsed = JSON.parse(data);
-    } catch (e: unknown) {
-        const message = e instanceof Error ? e.message : String(e);
+    } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
         throw new ValidationError(`Invalid JSON in dependency graph at ${graphPath}: ${message}`);
     }
 
@@ -37,13 +40,24 @@ export async function readDependencyGraph(graphPath: string): Promise<Dependency
     }));
 }
 
-export async function runEslintComplexityScan(sourcePath: string): Promise<EslintResult[]> {
-    try {
-        // Replace backslashes with forward slashes for cross-platform compatibility with globbing
-        const target = path.resolve(process.cwd(), sourcePath).replace(/\\/g, '/');
-        const globPattern = `${target}/**/*.{ts,tsx}`;
+export async function runEslintComplexityScan(
+    sourcePath: string,
+    sourceFiles?: string[],
+    cwd: string = process.cwd()
+): Promise<EslintResult[]> {
+    const target = path.resolve(cwd, sourcePath).replace(/\\/g, '/');
+    const globPattern = `${target}/**/*.{ts,tsx}`;
 
+    let targets: string[];
+    if (sourceFiles && sourceFiles.length > 0) {
+        targets = sourceFiles.map(f => path.resolve(cwd, f).replace(/\\/g, '/'));
+    } else {
+        targets = [globPattern];
+    }
+
+    try {
         const eslint = new ESLint({
+            cwd,
             overrideConfig: [{
                 rules: {
                     'complexity': ['warn', 0]
@@ -51,25 +65,57 @@ export async function runEslintComplexityScan(sourcePath: string): Promise<Eslin
             }]
         });
 
-        const results = await eslint.lintFiles([globPattern]);
+        const unignoredTargets: string[] = [];
+        const ignoredResults: EslintResult[] = [];
 
-        // Map ESLint's API results to the EslintResult interface we defined
-        return results.map(result => ({
-            filePath: result.filePath,
-            messages: result.messages.map(msg => ({
-                ruleId: msg.ruleId || 'unknown',
-                message: msg.message
-            }))
-        }));
-    } catch (e: unknown) {
-        const message = e instanceof Error ? e.message : String(e);
+        for (const t of targets) {
+            // Check if ESLint flat config ignores this path
+            const isIgnored = await eslint.isPathIgnored(t);
+            if (isIgnored) {
+                ignoredResults.push({
+                    filePath: t,
+                    ignored: true,
+                    messages: []
+                });
+            } else {
+                unignoredTargets.push(t);
+            }
+        }
+
+        let lintResults: EslintResult[] = [];
+        if (unignoredTargets.length > 0) {
+            const rawResults = await eslint.lintFiles(unignoredTargets);
+            lintResults = rawResults.map(result => ({
+                filePath: result.filePath,
+                ignored: Boolean((result as { ignored?: boolean }).ignored),
+                messages: result.messages.map(msg => ({
+                    ruleId: typeof msg.ruleId === 'string' ? msg.ruleId : 'unknown',
+                    message: msg.message
+                }))
+            }));
+        }
+
+        return [...lintResults, ...ignoredResults];
+    } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+
+        if (message.includes('All files matched') && message.includes('are ignored')) {
+            return targets.map(t => ({
+                filePath: t,
+                ignored: true,
+                messages: []
+            }));
+        }
+
         throw new Error(`Failed to run ESLint: ${message}`);
     }
 }
 
-export async function countLinesOfCode(sourceFiles: string[]): Promise<Record<string, number>> {
+export async function countLinesOfCode(
+    sourceFiles: string[],
+    cwd: string = process.cwd()
+): Promise<Record<string, number>> {
     const locMap: Record<string, number> = {};
-    const cwd = process.cwd();
 
     for (const file of sourceFiles) {
         try {
@@ -89,10 +135,9 @@ export async function writeOutputFiles(
     metricsPath: string,
     metricsData: unknown,
     reportPath: string,
-    reportData: string
+    reportData: string,
+    cwd: string = process.cwd()
 ): Promise<void> {
-    const cwd = process.cwd();
-
     const absMetricsPath = path.resolve(cwd, metricsPath);
     const absReportPath = path.resolve(cwd, reportPath);
 

--- a/src/cli/analyze/calculate-metrics.test.ts
+++ b/src/cli/analyze/calculate-metrics.test.ts
@@ -39,29 +39,29 @@ describe('calculate-metrics', () => {
 
         it('should return 100 for files within thresholds', () => {
             const files: FileMetric[] = [
-                { file: 'a.ts', loc: 100, complexity: 5, fanIn: 1, fanOut: 5, instability: 0.5, score: 0 }
+                { file: 'a.ts', loc: 100, complexity: 5, fanIn: 1, fanOut: 5, instability: 0.5, score: 0, scanned: true }
             ];
             expect(calculateHealthScore(files, thresholds)).toBe(100);
         });
 
         it('should deduct 1 point for each threshold exceeded', () => {
             const files: FileMetric[] = [
-                { file: 'a.ts', loc: 301, complexity: 5, fanIn: 1, fanOut: 5, instability: 0.5, score: 0 },
-                { file: 'b.ts', loc: 100, complexity: 11, fanIn: 1, fanOut: 5, instability: 0.5, score: 0 },
-                { file: 'c.ts', loc: 100, complexity: 5, fanIn: 1, fanOut: 16, instability: 0.5, score: 0 }
+                { file: 'a.ts', loc: 301, complexity: 5, fanIn: 1, fanOut: 5, instability: 0.5, score: 0, scanned: true },
+                { file: 'b.ts', loc: 100, complexity: 11, fanIn: 1, fanOut: 5, instability: 0.5, score: 0, scanned: true },
+                { file: 'c.ts', loc: 100, complexity: 5, fanIn: 1, fanOut: 16, instability: 0.5, score: 0, scanned: true }
             ];
             expect(calculateHealthScore(files, thresholds)).toBe(97);
         });
 
         it('should not deduct points if equal to threshold', () => {
             const files: FileMetric[] = [
-                { file: 'a.ts', loc: 300, complexity: 10, fanIn: 1, fanOut: 15, instability: 0.5, score: 0 }
+                { file: 'a.ts', loc: 300, complexity: 10, fanIn: 1, fanOut: 15, instability: 0.5, score: 0, scanned: true }
             ];
             expect(calculateHealthScore(files, thresholds)).toBe(100);
         });
 
         it('should clamp health score between 0 and 100', () => {
-            const files: FileMetric[] = Array(150).fill({ file: 'a.ts', loc: 400, complexity: 5, fanIn: 1, fanOut: 5, instability: 0.5, score: 0 }) as FileMetric[];
+            const files: FileMetric[] = Array(150).fill({ file: 'a.ts', loc: 400, complexity: 5, fanIn: 1, fanOut: 5, instability: 0.5, score: 0, scanned: true }) as FileMetric[];
             expect(calculateHealthScore(files, thresholds)).toBe(0);
         });
     });
@@ -93,14 +93,13 @@ describe('calculate-metrics', () => {
             'src': 10
         };
 
-        const complexityMap: Record<string, number> = {
-            'src/a.ts': 5,
-            'src/b.ts': 15,
-            'src': 1
+        const complexityMap = {
+            'src/a.ts': { complexity: 5, scanned: true },
+            'src/b.ts': { complexity: 15, scanned: true },
+            'src': { complexity: 1, scanned: true }
         };
 
         it('should filter out test files, .d.ts files, and non-source files correctly handling path boundaries', () => {
-            // Also tests with `src` as the exact prefix since normalization is handled prior to calculateMetrics
             const result = calculateMetrics(modules, locMap, complexityMap, thresholds, 'src');
 
             expect(result.files.length).toBe(3); // src/a.ts, src/b.ts, and src itself
@@ -113,14 +112,16 @@ describe('calculate-metrics', () => {
         it('should correctly sort files by score and complexity', () => {
              const result = calculateMetrics(modules, locMap, complexityMap, thresholds, 'src');
 
-             // b.ts should have higher score and complexity
              expect(result.topByScore[0].file).toBe('src/b.ts');
              expect(result.topByComplexity[0].file).toBe('src/b.ts');
         });
 
-        it('should handle missing complexity with default 1', () => {
+        it('should identify unmeasured files when missing from complexity map', () => {
              const result = calculateMetrics([{ source: 'src/a.ts', dependencies: [], dependents: [] }], {'src/a.ts': 100}, {}, thresholds, 'src');
-             expect(result.files[0].complexity).toBe(1);
+             expect(result.files[0].complexity).toBe(0);
+             expect(result.files[0].scanned).toBe(false);
+             expect(result.skippedCount).toBe(1);
+             expect(result.unmeasuredFiles).toEqual(['src/a.ts']);
         });
     });
 });

--- a/src/cli/analyze/calculate-metrics.ts
+++ b/src/cli/analyze/calculate-metrics.ts
@@ -1,4 +1,4 @@
-import type { FileMetric, AnalysisThresholds, AnalysisResult, DependencyCruiserModule } from './models';
+import type { FileMetric, AnalysisThresholds, AnalysisResult, DependencyCruiserModule, EslintFileComplexity } from './models';
 
 export function calculateInstability(fanIn: number, fanOut: number): number {
     if (fanIn + fanOut === 0) {
@@ -26,7 +26,7 @@ export function calculateHealthScore(files: FileMetric[], thresholds: AnalysisTh
 export function calculateMetrics(
     modules: DependencyCruiserModule[],
     locMap: Record<string, number>,
-    complexityMap: Record<string, number>,
+    complexityMap: Record<string, EslintFileComplexity | number>,
     thresholds: AnalysisThresholds,
     sourcePrefix: string = 'src'
 ): AnalysisResult {
@@ -47,7 +47,20 @@ export function calculateMetrics(
             const fanIn = m.dependents.length;
 
             const instability = calculateInstability(fanIn, fanOut);
-            const complexity = complexityMap[m.source] || 1;
+
+            let complexity = 0;
+            let scanned = false;
+
+            const eslintData = complexityMap[m.source];
+            if (eslintData !== undefined) {
+                if (typeof eslintData === 'object' && eslintData !== null) {
+                    complexity = eslintData.complexity;
+                    scanned = eslintData.scanned;
+                } else if (typeof eslintData === 'number') {
+                    complexity = eslintData;
+                    scanned = true;
+                }
+            }
 
             const score = calculateScore(loc, complexity, fanOut, instability);
 
@@ -58,11 +71,15 @@ export function calculateMetrics(
                 fanIn,
                 instability: parseFloat(instability.toFixed(2)),
                 complexity,
-                score: parseFloat(score.toFixed(1))
+                score: parseFloat(score.toFixed(1)),
+                scanned
             };
         });
 
     const healthScore = calculateHealthScore(files, thresholds);
+
+    const unmeasuredFiles = files.filter(f => !f.scanned).map(f => f.file);
+    const skippedCount = unmeasuredFiles.length;
 
     // Create stable sorts to break ties by file name
     const topByScore = [...files].sort((a, b) => {
@@ -79,6 +96,8 @@ export function calculateMetrics(
         files,
         healthScore: parseFloat(healthScore.toFixed(1)),
         topByScore,
-        topByComplexity
+        topByComplexity,
+        skippedCount,
+        unmeasuredFiles
     };
 }

--- a/src/cli/analyze/environment.test.ts
+++ b/src/cli/analyze/environment.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { validateNodeVersion, detectEslintConfig, validateEslintEnvironment } from './environment';
+import { ValidationError } from './models';
+
+describe('environment', () => {
+    describe('validateNodeVersion', () => {
+        it('should accept Node 20.19.0 and higher', () => {
+            expect(() => validateNodeVersion('20.19.0')).not.toThrow();
+            expect(() => validateNodeVersion('v20.19.0')).not.toThrow();
+            expect(() => validateNodeVersion('20.20.0')).not.toThrow();
+            expect(() => validateNodeVersion('22.0.0')).not.toThrow();
+        });
+
+        it('should reject Node versions below 20.19.0', () => {
+            expect(() => validateNodeVersion('18.20.0')).toThrow(ValidationError);
+            expect(() => validateNodeVersion('18.20.0')).toThrow(/requires Node.js >=20.19.0/);
+            expect(() => validateNodeVersion('20.18.3')).toThrow(ValidationError);
+        });
+    });
+
+    describe('detectEslintConfig', () => {
+        const testDir = path.join(process.cwd(), 'temp-test-env');
+
+        beforeEach(() => {
+            if (fs.existsSync(testDir)) {
+                fs.rmSync(testDir, { recursive: true, force: true });
+            }
+            fs.mkdirSync(testDir, { recursive: true });
+        });
+
+        afterEach(() => {
+            if (fs.existsSync(testDir)) {
+                fs.rmSync(testDir, { recursive: true, force: true });
+            }
+        });
+
+        it('should detect legacy .eslintrc.cjs', () => {
+            fs.writeFileSync(path.join(testDir, '.eslintrc.cjs'), 'module.exports = {};');
+            const result = detectEslintConfig(testDir);
+            expect(result.isLegacy).toBe(true);
+            expect(result.legacyFile).toBe('.eslintrc.cjs');
+            expect(result.mode).toBe('Legacy');
+        });
+
+        it('should detect legacy eslintConfig in package.json', () => {
+            fs.writeFileSync(path.join(testDir, 'package.json'), JSON.stringify({ eslintConfig: { extends: ['eslint:recommended'] } }));
+            const result = detectEslintConfig(testDir);
+            expect(result.isLegacy).toBe(true);
+            expect(result.legacyFile).toBe('package.json (eslintConfig)');
+        });
+
+        it('should detect flat config eslint.config.js', () => {
+            fs.writeFileSync(path.join(testDir, 'eslint.config.js'), 'export default [];');
+            const result = detectEslintConfig(testDir);
+            expect(result.isLegacy).toBe(false);
+            expect(result.mode).toBe('Flat Config (eslint.config.js)');
+        });
+
+        it('should fallback to default flat config if no config file present', () => {
+            const result = detectEslintConfig(testDir);
+            expect(result.isLegacy).toBe(false);
+            expect(result.mode).toBe('Flat Config (default)');
+        });
+    });
+
+    describe('validateEslintEnvironment', () => {
+        const testDir = path.join(process.cwd(), 'temp-test-env-val');
+
+        beforeEach(() => {
+            if (fs.existsSync(testDir)) {
+                fs.rmSync(testDir, { recursive: true, force: true });
+            }
+            fs.mkdirSync(testDir, { recursive: true });
+        });
+
+        afterEach(() => {
+            if (fs.existsSync(testDir)) {
+                fs.rmSync(testDir, { recursive: true, force: true });
+            }
+        });
+
+        it('should throw ValidationError on legacy config', () => {
+            fs.writeFileSync(path.join(testDir, '.eslintrc.json'), '{}');
+            expect(() => validateEslintEnvironment(testDir, '22.0.0')).toThrow(ValidationError);
+            expect(() => validateEslintEnvironment(testDir, '22.0.0')).toThrow(/Legacy ESLint configuration detected \(\.eslintrc\.json\)/);
+        });
+
+        it('should succeed on valid environment and flat config', () => {
+            fs.writeFileSync(path.join(testDir, 'eslint.config.mjs'), 'export default [];');
+            const result = validateEslintEnvironment(testDir, '20.19.0');
+            expect(result.mode).toBe('Flat Config (eslint.config.mjs)');
+        });
+    });
+});

--- a/src/cli/analyze/environment.ts
+++ b/src/cli/analyze/environment.ts
@@ -1,0 +1,87 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { ValidationError } from './models';
+
+const LEGACY_CONFIG_FILES = [
+    '.eslintrc',
+    '.eslintrc.js',
+    '.eslintrc.cjs',
+    '.eslintrc.mjs',
+    '.eslintrc.json',
+    '.eslintrc.yaml',
+    '.eslintrc.yml'
+];
+
+const FLAT_CONFIG_FILES = [
+    'eslint.config.js',
+    'eslint.config.mjs',
+    'eslint.config.cjs',
+    'eslint.config.ts',
+    'eslint.config.mts',
+    'eslint.config.cts'
+];
+
+export function validateNodeVersion(nodeVersionStr: string = process.versions.node): void {
+    const cleanVersion = nodeVersionStr.replace(/^v/, '');
+    const parts = cleanVersion.split('.').map(p => parseInt(p, 10));
+    const major = parts[0] || 0;
+    const minor = parts[1] || 0;
+
+    // Baseline requirement: Node >= 20.19.0
+    if (major < 20 || (major === 20 && minor < 19)) {
+        throw new ValidationError(
+            `Maritime requires Node.js >=20.19.0 (current version: v${cleanVersion}).`
+        );
+    }
+}
+
+export function detectEslintConfig(cwd: string = process.cwd()): {
+    mode: string;
+    isLegacy: boolean;
+    legacyFile?: string;
+} {
+    for (const legacyFile of LEGACY_CONFIG_FILES) {
+        const fullPath = path.join(cwd, legacyFile);
+        if (fs.existsSync(fullPath)) {
+            return { mode: 'Legacy', isLegacy: true, legacyFile };
+        }
+    }
+
+    const pkgPath = path.join(cwd, 'package.json');
+    if (fs.existsSync(pkgPath)) {
+        try {
+            const content = fs.readFileSync(pkgPath, 'utf8');
+            const parsed = JSON.parse(content) as Record<string, unknown>;
+            if (parsed && typeof parsed === 'object' && 'eslintConfig' in parsed && parsed.eslintConfig !== undefined) {
+                return { mode: 'Legacy', isLegacy: true, legacyFile: 'package.json (eslintConfig)' };
+            }
+        } catch {
+            // Ignore package.json parse errors here; handled elsewhere if malformed
+        }
+    }
+
+    for (const flatFile of FLAT_CONFIG_FILES) {
+        const fullPath = path.join(cwd, flatFile);
+        if (fs.existsSync(fullPath)) {
+            return { mode: `Flat Config (${flatFile})`, isLegacy: false };
+        }
+    }
+
+    return { mode: 'Flat Config (default)', isLegacy: false };
+}
+
+export function validateEslintEnvironment(
+    cwd: string = process.cwd(),
+    nodeVersionStr?: string
+): { mode: string } {
+    validateNodeVersion(nodeVersionStr);
+
+    const detected = detectEslintConfig(cwd);
+    if (detected.isLegacy) {
+        throw new ValidationError(
+            `Legacy ESLint configuration detected (${detected.legacyFile}). Maritime requires ESLint 9+ flat configuration (eslint.config.*).`
+        );
+    }
+
+    return { mode: detected.mode };
+}

--- a/src/cli/analyze/models.ts
+++ b/src/cli/analyze/models.ts
@@ -6,6 +6,7 @@ export interface FileMetric {
     fanOut: number;
     instability: number;
     score: number;
+    scanned: boolean;
 }
 
 export interface AnalysisThresholds {
@@ -21,6 +22,8 @@ export interface AnalysisResult {
     healthScore: number;
     topByScore: FileMetric[];
     topByComplexity: FileMetric[];
+    skippedCount: number;
+    unmeasuredFiles: string[];
 }
 
 export interface EslintMessage {
@@ -31,6 +34,12 @@ export interface EslintMessage {
 export interface EslintResult {
     filePath: string;
     messages: EslintMessage[];
+    ignored?: boolean;
+}
+
+export interface EslintFileComplexity {
+    complexity: number;
+    scanned: boolean;
 }
 
 export interface DependencyCruiserModule {

--- a/src/cli/analyze/parse-eslint.test.ts
+++ b/src/cli/analyze/parse-eslint.test.ts
@@ -4,7 +4,7 @@ import type { EslintResult } from './models';
 
 describe('parse-eslint', () => {
     describe('parseEslintComplexityReport', () => {
-        it('should extract max complexity from ESLint JSON output', () => {
+        it('should extract max complexity and scanned status from ESLint output', () => {
             const eslintResults: EslintResult[] = [
                 {
                     filePath: '/path/to/project/src/a.ts',
@@ -18,31 +18,36 @@ describe('parse-eslint', () => {
                     messages: [
                         { ruleId: 'no-unused-vars', message: "Var unused." }
                     ]
+                },
+                {
+                    filePath: '/path/to/project/build/sites-vite-plugin.ts',
+                    ignored: true,
+                    messages: []
                 }
             ];
 
             const result = parseEslintComplexityReport(eslintResults, '/path/to/project');
 
-            // Normalize path to relative path
-            expect(result['src/a.ts']).toBe(15);
-            expect(result['src/b.ts']).toBeUndefined();
+            expect(result['src/a.ts']).toEqual({ complexity: 15, scanned: true });
+            expect(result['src/b.ts']).toEqual({ complexity: 1, scanned: true });
+            expect(result['build/sites-vite-plugin.ts']).toEqual({ complexity: 0, scanned: false });
         });
 
-        it('should handle invalid or empty ESLint output', () => {
+        it('should handle empty ESLint output', () => {
             expect(parseEslintComplexityReport([], '/path/to/project')).toEqual({});
         });
 
-        it('should safely ignore non-complexity rule messages', () => {
-             const eslintResults: EslintResult[] = [
+        it('should report base complexity 1 and scanned: true when no complexity messages are generated', () => {
+            const eslintResults: EslintResult[] = [
                 {
                     filePath: '/project/src/a.ts',
                     messages: [
-                        { ruleId: 'other-rule', message: "Function 'X' has a complexity of 10. Maximum allowed is 0." },
+                        { ruleId: 'other-rule', message: "Some other error." }
                     ]
                 }
             ];
             const result = parseEslintComplexityReport(eslintResults, '/project');
-            expect(result['src/a.ts']).toBeUndefined();
+            expect(result['src/a.ts']).toEqual({ complexity: 1, scanned: true });
         });
     });
 });

--- a/src/cli/analyze/parse-eslint.ts
+++ b/src/cli/analyze/parse-eslint.ts
@@ -1,10 +1,20 @@
 import * as path from 'path';
-import type { EslintResult } from './models';
+import type { EslintResult, EslintFileComplexity } from './models';
 
-export function parseEslintComplexityReport(eslintResults: EslintResult[], cwd: string): Record<string, number> {
-    const complexityMap: Record<string, number> = {};
+export function parseEslintComplexityReport(
+    eslintResults: EslintResult[],
+    cwd: string
+): Record<string, EslintFileComplexity> {
+    const complexityMap: Record<string, EslintFileComplexity> = {};
 
     for (const file of eslintResults) {
+        const relPath = path.relative(cwd, file.filePath).replace(/\\/g, '/');
+
+        if (file.ignored) {
+            complexityMap[relPath] = { complexity: 0, scanned: false };
+            continue;
+        }
+
         let maxC = 0;
         for (const msg of file.messages) {
             if (msg.ruleId === 'complexity') {
@@ -18,12 +28,10 @@ export function parseEslintComplexityReport(eslintResults: EslintResult[], cwd: 
             }
         }
 
-        if (maxC > 0) {
-            // Use path.relative to get the relative path to CWD, avoiding hardcoded process.cwd() for purity
-            // Path module handles cross-platform logic, but replacing backslashes ensures consistent output format
-            const relPath = path.relative(cwd, file.filePath).replace(/\\/g, '/');
-            complexityMap[relPath] = maxC;
-        }
+        complexityMap[relPath] = {
+            complexity: maxC > 0 ? maxC : 1,
+            scanned: true
+        };
     }
 
     return complexityMap;

--- a/src/cli/analyze/render-markdown-report.test.ts
+++ b/src/cli/analyze/render-markdown-report.test.ts
@@ -12,15 +12,17 @@ describe('render-markdown-report', () => {
 
         const result: AnalysisResult = {
             files: [
-                { file: 'src/a.ts', loc: 100, complexity: 5, fanIn: 1, fanOut: 5, instability: 0.5, score: 34 }
+                { file: 'src/a.ts', loc: 100, complexity: 5, fanIn: 1, fanOut: 5, instability: 0.5, score: 34, scanned: true }
             ],
             healthScore: 100,
             topByScore: [
-                { file: 'src/a.ts', loc: 100, complexity: 5, fanIn: 1, fanOut: 5, instability: 0.5, score: 34 }
+                { file: 'src/a.ts', loc: 100, complexity: 5, fanIn: 1, fanOut: 5, instability: 0.5, score: 34, scanned: true }
             ],
             topByComplexity: [
-                { file: 'src/a.ts', loc: 100, complexity: 5, fanIn: 1, fanOut: 5, instability: 0.5, score: 34 }
-            ]
+                { file: 'src/a.ts', loc: 100, complexity: 5, fanIn: 1, fanOut: 5, instability: 0.5, score: 34, scanned: true }
+            ],
+            skippedCount: 0,
+            unmeasuredFiles: []
         };
 
         const reportDate = new Date('2024-01-01T00:00:00.000Z');
@@ -46,9 +48,11 @@ describe('render-markdown-report', () => {
             files: [],
             healthScore: 100,
             topByScore: [
-                { file: 'src/_internal_/a.ts', loc: 100, complexity: 5, fanIn: 1, fanOut: 5, instability: 0.5, score: 34 }
+                { file: 'src/_internal_/a.ts', loc: 100, complexity: 5, fanIn: 1, fanOut: 5, instability: 0.5, score: 34, scanned: true }
             ],
-            topByComplexity: []
+            topByComplexity: [],
+            skippedCount: 0,
+            unmeasuredFiles: []
         };
         const thresholds: AnalysisThresholds = { loc: 300, complexity: 10, fanOut: 15 };
         const reportDate = new Date('2024-01-01T00:00:00.000Z');

--- a/src/cli/commands/analyze.fixtures.test.ts
+++ b/src/cli/commands/analyze.fixtures.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { runAnalyzeCommand } from './analyze';
+import type { FileMetric } from '../analyze/models';
+
+describe('analyze command integration fixtures', () => {
+    const fixtureRoot = path.join(process.cwd(), 'temp-analyze-fixtures');
+
+    beforeEach(() => {
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        if (fs.existsSync(fixtureRoot)) {
+            fs.rmSync(fixtureRoot, { recursive: true, force: true });
+        }
+        fs.mkdirSync(fixtureRoot, { recursive: true });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        if (fs.existsSync(fixtureRoot)) {
+            fs.rmSync(fixtureRoot, { recursive: true, force: true });
+        }
+    });
+
+    function createGraphJson(dir: string, sources: string[]): string {
+        const graphPath = path.join(dir, 'dependency-graph.json');
+        const data = {
+            modules: sources.map(src => ({
+                source: src,
+                valid: true,
+                dependencies: [],
+                dependents: []
+            })),
+            summary: {
+                error: 0,
+                ignore: 0,
+                info: 0,
+                totalCruised: sources.length,
+                violations: [],
+                warn: 0,
+                optionsUsed: {}
+            }
+        };
+        fs.writeFileSync(graphPath, JSON.stringify(data, null, 2));
+        return 'dependency-graph.json';
+    }
+
+    it('flat-config fixture: successful analysis', async () => {
+        const dir = path.join(fixtureRoot, 'flat-config');
+        fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+
+        fs.writeFileSync(path.join(dir, 'eslint.config.js'), 'export default [{ files: ["**/*.ts", "**/*.tsx"] }];');
+        fs.writeFileSync(path.join(dir, 'src', 'index.ts'), 'export const x = 1;\nfunction foo(a: number) { return a + 1; }\n');
+
+        const graphFile = createGraphJson(dir, ['src/index.ts']);
+
+        const exitCode = await runAnalyzeCommand([
+            '--cwd', dir,
+            '--graph', graphFile,
+            '--metrics', 'metrics.json',
+            '--report', 'report.md'
+        ]);
+
+        expect(exitCode).toBe(0);
+
+        const metricsData = JSON.parse(fs.readFileSync(path.join(dir, 'metrics.json'), 'utf8')) as Record<string, FileMetric>;
+        expect(metricsData['src/index.ts']).toBeDefined();
+        expect(metricsData['src/index.ts'].scanned).toBe(true);
+        expect(metricsData['src/index.ts'].complexity).toBeGreaterThanOrEqual(1);
+
+        const reportData = fs.readFileSync(path.join(dir, 'report.md'), 'utf8');
+        expect(reportData).toContain('Automated Complexity Report');
+    });
+
+    it('legacy .eslintrc fixture: intentional exit code 2 and actionable message', async () => {
+        const dir = path.join(fixtureRoot, 'legacy-eslintrc');
+        fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+
+        fs.writeFileSync(path.join(dir, '.eslintrc.cjs'), 'module.exports = {};');
+        fs.writeFileSync(path.join(dir, 'src', 'index.ts'), 'export const x = 1;');
+
+        const graphFile = createGraphJson(dir, ['src/index.ts']);
+
+        const exitCode = await runAnalyzeCommand([
+            '--cwd', dir,
+            '--graph', graphFile,
+            '--metrics', 'metrics.json',
+            '--report', 'report.md'
+        ]);
+
+        expect(exitCode).toBe(2);
+        expect(console.error).toHaveBeenCalledWith(
+            expect.stringContaining('Legacy ESLint configuration detected (.eslintrc.cjs)')
+        );
+        expect(console.error).toHaveBeenCalledWith(
+            expect.stringContaining('Maritime requires ESLint 9+ flat configuration')
+        );
+    });
+
+    it('legacy package.json eslintConfig fixture: exit code 2 and actionable message', async () => {
+        const dir = path.join(fixtureRoot, 'legacy-package-json');
+        fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+
+        fs.writeFileSync(
+            path.join(dir, 'package.json'),
+            JSON.stringify({ name: 'legacy-pkg', eslintConfig: { extends: ['eslint:recommended'] } })
+        );
+        fs.writeFileSync(path.join(dir, 'src', 'index.ts'), 'export const x = 1;');
+
+        const graphFile = createGraphJson(dir, ['src/index.ts']);
+
+        const exitCode = await runAnalyzeCommand([
+            '--cwd', dir,
+            '--graph', graphFile,
+            '--metrics', 'metrics.json',
+            '--report', 'report.md'
+        ]);
+
+        expect(exitCode).toBe(2);
+        expect(console.error).toHaveBeenCalledWith(
+            expect.stringContaining('Legacy ESLint configuration detected (package.json (eslintConfig))')
+        );
+    });
+
+    it('ignored-file fixture: TypeScript file excluded by ESLint identified as unmeasured/skipped', async () => {
+        const dir = path.join(fixtureRoot, 'ignored-file');
+        fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+        fs.mkdirSync(path.join(dir, 'build'), { recursive: true });
+
+        fs.writeFileSync(
+            path.join(dir, 'eslint.config.js'),
+            'export default [{ files: ["**/*.ts", "**/*.tsx"] }, { ignores: ["build/**"] }];'
+        );
+        fs.writeFileSync(path.join(dir, 'src', 'app.ts'), 'export const app = "app";');
+        fs.writeFileSync(path.join(dir, 'build', 'sites-vite-plugin.ts'), 'export const plugin = "plugin";');
+
+        const graphFile = createGraphJson(dir, ['src/app.ts', 'build/sites-vite-plugin.ts']);
+
+        const exitCode = await runAnalyzeCommand([
+            '--cwd', dir,
+            '--source', '.',
+            '--graph', graphFile,
+            '--metrics', 'metrics.json',
+            '--report', 'report.md'
+        ]);
+
+        expect(exitCode).toBe(0);
+
+        const metricsData = JSON.parse(fs.readFileSync(path.join(dir, 'metrics.json'), 'utf8')) as Record<string, FileMetric>;
+
+        expect(metricsData['src/app.ts']).toBeDefined();
+        expect(metricsData['src/app.ts'].scanned).toBe(true);
+        expect(metricsData['src/app.ts'].complexity).toBe(1);
+
+        expect(metricsData['build/sites-vite-plugin.ts']).toBeDefined();
+        expect(metricsData['build/sites-vite-plugin.ts'].scanned).toBe(false);
+        expect(metricsData['build/sites-vite-plugin.ts'].complexity).toBe(0);
+
+        expect(console.warn).toHaveBeenCalledWith(
+            expect.stringContaining('1 graph source file(s) were skipped or ignored by ESLint')
+        );
+        expect(console.warn).toHaveBeenCalledWith(
+            expect.stringContaining('build/sites-vite-plugin.ts')
+        );
+    });
+
+    it('ignored-file fixture with --fail-on-unmeasured: fails with exit code 2', async () => {
+        const dir = path.join(fixtureRoot, 'ignored-file-fail');
+        fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+        fs.mkdirSync(path.join(dir, 'build'), { recursive: true });
+
+        fs.writeFileSync(
+            path.join(dir, 'eslint.config.js'),
+            'export default [{ files: ["**/*.ts", "**/*.tsx"] }, { ignores: ["build/**"] }];'
+        );
+        fs.writeFileSync(path.join(dir, 'src', 'app.ts'), 'export const app = "app";');
+        fs.writeFileSync(path.join(dir, 'build', 'sites-vite-plugin.ts'), 'export const plugin = "plugin";');
+
+        const graphFile = createGraphJson(dir, ['src/app.ts', 'build/sites-vite-plugin.ts']);
+
+        const exitCode = await runAnalyzeCommand([
+            '--cwd', dir,
+            '--source', '.',
+            '--graph', graphFile,
+            '--metrics', 'metrics.json',
+            '--report', 'report.md',
+            '--fail-on-unmeasured'
+        ]);
+
+        expect(exitCode).toBe(2);
+        expect(console.error).toHaveBeenCalledWith(
+            expect.stringContaining('Analysis failed because 1 graph source file(s) were not scanned by ESLint')
+        );
+    });
+});

--- a/src/cli/commands/analyze.test.ts
+++ b/src/cli/commands/analyze.test.ts
@@ -5,13 +5,16 @@ import * as adapters from '../analyze/adapters';
 describe('runAnalyzeCommand', () => {
     beforeEach(() => {
         vi.spyOn(console, 'log').mockImplementation(() => {});
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
         vi.spyOn(console, 'error').mockImplementation(() => {});
 
         vi.spyOn(adapters, 'readDependencyGraph').mockResolvedValue([
             { source: 'src/a.ts', dependencies: [], dependents: [] }
         ]);
 
-        vi.spyOn(adapters, 'runEslintComplexityScan').mockResolvedValue([]);
+        vi.spyOn(adapters, 'runEslintComplexityScan').mockResolvedValue([
+            { filePath: `${process.cwd()}/src/a.ts`, messages: [] }
+        ]);
         vi.spyOn(adapters, 'countLinesOfCode').mockResolvedValue({ 'src/a.ts': 100 });
         vi.spyOn(adapters, 'writeOutputFiles').mockResolvedValue(undefined);
     });
@@ -41,7 +44,7 @@ describe('runAnalyzeCommand', () => {
         ]);
 
         expect(exitCode).toBe(0);
-        expect(adapters.readDependencyGraph).toHaveBeenCalledWith('graph.json');
+        expect(adapters.readDependencyGraph).toHaveBeenCalledWith('graph.json', expect.any(String));
         expect(adapters.writeOutputFiles).toHaveBeenCalled();
     });
 });

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -8,6 +8,7 @@ import {
 import { calculateMetrics } from '../analyze/calculate-metrics';
 import { parseEslintComplexityReport } from '../analyze/parse-eslint';
 import { renderMarkdownReport } from '../analyze/render-markdown-report';
+import { validateEslintEnvironment } from '../analyze/environment';
 import { ValidationError, type AnalysisThresholds } from '../analyze/models';
 import * as path from 'path';
 
@@ -23,6 +24,8 @@ export async function runAnalyzeCommand(args: string[]): Promise<number> {
         graph?: string;
         metrics?: string;
         report?: string;
+        cwd?: string;
+        'fail-on-unmeasured'?: boolean;
         help?: boolean;
     };
 
@@ -35,6 +38,8 @@ export async function runAnalyzeCommand(args: string[]): Promise<number> {
                 graph: { type: 'string' },
                 metrics: { type: 'string' },
                 report: { type: 'string' },
+                cwd: { type: 'string' },
+                'fail-on-unmeasured': { type: 'boolean', default: false },
                 help: { type: 'boolean', short: 'h' }
             }
         });
@@ -47,20 +52,22 @@ export async function runAnalyzeCommand(args: string[]): Promise<number> {
 
     if (values.help) {
         console.log(`
-Usage: maritime analyze --graph <file> --metrics <file> --report <file> [--source <dir>]
+Usage: maritime analyze --graph <file> --metrics <file> --report <file> [--source <dir>] [--cwd <dir>] [--fail-on-unmeasured]
 
 Options:
-  --graph <file>     Input dependency-cruiser JSON
-  --metrics <file>   Output JSON file for metrics
-  --report <file>    Output Markdown file for the report
-  --source <dir>     Source directory to analyze (default: "src")
+  --graph <file>            Input dependency-cruiser JSON
+  --metrics <file>          Output JSON file for metrics
+  --report <file>           Output Markdown file for the report
+  --source <dir>            Source directory to analyze (default: "src")
+  --cwd <dir>               Working directory root for resolution
+  --fail-on-unmeasured      Fail if any graph source file is skipped/unmeasured by ESLint
 
 Note: analyze consumes a dependency graph; it does not generate one.
 
 Exit Codes:
   0 - Successful analysis
   1 - Operational or runtime failure
-  2 - Invalid CLI arguments or invalid input artifact/schema
+  2 - Invalid CLI arguments, environment, or invalid input artifact/schema
         `);
         return 0;
     }
@@ -70,43 +77,50 @@ Exit Codes:
         return 2;
     }
 
-    try {
+    const workingDir = values.cwd ? path.resolve(values.cwd) : process.cwd();
 
+    try {
         console.log('📊 Starting Complexity Analysis...');
 
-        // 1. Read input graph
+        // 1. Validate environment & ESLint flat config baseline
+        console.log('   - Validating Environment & Configuration...');
+        const { mode: eslintConfigMode } = validateEslintEnvironment(workingDir);
+
+        console.log(`   - Working Directory: ${workingDir}`);
+        console.log(`   - Graph Path: ${values.graph}`);
+        console.log(`   - ESLint Config Mode: ${eslintConfigMode}`);
+
+        // 2. Read input graph
         console.log('   - Reading Dependency Cruiser JSON...');
-        const modules = await readDependencyGraph(values.graph);
+        const modules = await readDependencyGraph(values.graph, workingDir);
 
         const rawSource = values.source || 'src';
 
-        // 2. ESLint for complexity
-        console.log('   - Running ESLint for Complexity...');
-        const eslintResults = await runEslintComplexityScan(rawSource);
-        const complexityMap = parseEslintComplexityReport(eslintResults, process.cwd());
-
         // Convert to a repo-relative path, replacing backslashes with forward slashes
-        // This handles absolute paths, './src', 'src/', etc., cleanly relative to cwd
-        let normalizedSource = path.relative(process.cwd(), path.resolve(process.cwd(), rawSource)).replace(/\\/g, '/');
+        let normalizedSource = path.relative(workingDir, path.resolve(workingDir, rawSource)).replace(/\\/g, '/');
         if (normalizedSource === '') normalizedSource = '.';
 
-        // 3. Count LOC
-        console.log('   - Counting Lines of Code...');
-
-        // Match paths similarly to calculate-metrics boundary logic
         const prefixBoundary = normalizedSource === '.' ? '' : `${normalizedSource}/`;
 
         const sourceFiles = modules
             .map(m => m.source)
             .filter(src => {
-                return normalizedSource === '.'
+                const isSource = normalizedSource === '.'
                     ? true
                     : src === normalizedSource || src.startsWith(prefixBoundary);
+                return isSource && !src.includes('.test.') && !src.includes('.d.ts');
             });
 
-        const locMap = await countLinesOfCode(sourceFiles);
+        // 3. ESLint for complexity
+        console.log('   - Running ESLint for Complexity...');
+        const eslintResults = await runEslintComplexityScan(rawSource, sourceFiles, workingDir);
+        const complexityMap = parseEslintComplexityReport(eslintResults, workingDir);
 
-        // 4. Calculate metrics
+        // 4. Count LOC
+        console.log('   - Counting Lines of Code...');
+        const locMap = await countLinesOfCode(sourceFiles, workingDir);
+
+        // 5. Calculate metrics
         console.log('   - Aggregating Metrics...');
         const analysisResult = calculateMetrics(
             modules,
@@ -116,24 +130,37 @@ Exit Codes:
             normalizedSource
         );
 
-        // 5. Generate metrics and report
+        console.log(`   - Skipped / Unmeasured Source Files: ${analysisResult.skippedCount}`);
+
+        if (analysisResult.skippedCount > 0) {
+            console.warn(`⚠️ Warning: ${analysisResult.skippedCount} graph source file(s) were skipped or ignored by ESLint and could not be measured:`);
+            analysisResult.unmeasuredFiles.forEach(f => console.warn(`   - ${f}`));
+
+            if (values['fail-on-unmeasured']) {
+                throw new ValidationError(
+                    `Analysis failed because ${analysisResult.skippedCount} graph source file(s) were not scanned by ESLint (--fail-on-unmeasured).`
+                );
+            }
+        }
+
+        // 6. Generate metrics and report
         console.log('   - Generating Outputs...');
 
-        // Match the previous script's output format: simple Record<string, FileMetric> for --metrics
         const metricsMap = analysisResult.files.reduce((acc, f) => {
             acc[f.file] = {
                 complexity: f.complexity,
                 loc: f.loc,
                 instability: f.instability,
                 fanIn: f.fanIn,
-                fanOut: f.fanOut
+                fanOut: f.fanOut,
+                scanned: f.scanned
             };
             return acc;
         }, {} as Record<string, unknown>);
 
         const reportContent = renderMarkdownReport(analysisResult, DEFAULT_THRESHOLDS);
 
-        await writeOutputFiles(values.metrics, metricsMap, values.report, reportContent);
+        await writeOutputFiles(values.metrics, metricsMap, values.report, reportContent, workingDir);
 
         console.log('✅ Complexity Report Updated and Metrics Exported!');
         return 0;

--- a/src/schema/complexity-metrics.ts
+++ b/src/schema/complexity-metrics.ts
@@ -6,6 +6,7 @@ export const ComplexityMetricSchema = z.object({
   instability: z.number().optional(),
   fanIn: z.number().optional(),
   fanOut: z.number().optional(),
+  scanned: z.boolean().optional(),
 });
 
 export const ComplexityMetricsMapSchema = z.record(z.string(), ComplexityMetricSchema);


### PR DESCRIPTION
Enforces Node.js >=20.19.0 runtime baseline and ESLint 9+ flat configuration for maritime analyze. Detects and rejects legacy .eslintrc.* and eslintConfig package metadata before execution with exit code 2. Integrates ESLint path ignore checking to track scanned files vs unmeasured files, ensuring ignored graph source files are reported as unmeasured (scanned: false) rather than inferred complexity 1. Adds diagnostic logging and --fail-on-unmeasured CLI option.

Fixes #197

---
*PR created automatically by Jules for task [15510444513872597665](https://jules.google.com/task/15510444513872597665) started by @g1ddy*