### PR TITLE
fix(e2e): stabilize Mobile Safari graph interactions

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,9 +8,6 @@ export default defineConfig({
   // write to shared output paths. Keep them out of the browser-compatibility
   // suite so `test:e2e` does not regenerate each image three times.
   testIgnore: 'generate-screenshots.spec.ts',
-  // WebKit can spend most of Playwright's 30-second default starting the
-  // dependency graph on constrained single-worker CI runners.
-  timeout: 60 * 1000,
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,13 @@ const BASE_URL = 'http://localhost:5173/dependency-maritime/';
 
 export default defineConfig({
   testDir: './tests/e2e',
+  // Documentation screenshots have their own single-project configuration and
+  // write to shared output paths. Keep them out of the browser-compatibility
+  // suite so `test:e2e` does not regenerate each image three times.
+  testIgnore: 'generate-screenshots.spec.ts',
+  // WebKit can spend most of Playwright's 30-second default starting the
+  // dependency graph on constrained single-worker CI runners.
+  timeout: 60 * 1000,
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/src/features/visualization/components/DependencyGraph.tsx
+++ b/src/features/visualization/components/DependencyGraph.tsx
@@ -217,9 +217,12 @@ export function DependencyGraph() {
 
   const onNodeClick = useCallback(
     (_: React.MouseEvent, node: Node) => {
-      // Only auto-open inspector on desktop (>= 768px)
-      const isDesktop = window.matchMedia?.('(min-width: 768px)').matches ?? true;
-      selectNode(node.id, isDesktop);
+      // Auto-open the inspector only for desktop-style pointer input. Wide touch
+      // tablets such as iPad can exceed the desktop breakpoint but should retain
+      // the mobile interaction model so the inspector does not cover the graph.
+      const hasDesktopWidth = window.matchMedia?.('(min-width: 768px)').matches ?? true;
+      const hasFinePointer = window.matchMedia?.('(pointer: fine)').matches ?? true;
+      selectNode(node.id, hasDesktopWidth && hasFinePointer);
     },
     [selectNode]
   );

--- a/src/features/visualization/components/DependencyGraph.tsx
+++ b/src/features/visualization/components/DependencyGraph.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useCallback, useRef, useState } from 'react';
+import { useEffect, useMemo, useCallback, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { ReactFlow, Background, Controls, MiniMap, useReactFlow, type Node } from '@xyflow/react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -53,7 +53,7 @@ export function DependencyGraph() {
   })));
 
   const { getIntersectingNodes, getInternalNode, getNode, fitView } = useReactFlow();
-  const [interactionReady, setInteractionReady] = useState(false);
+  const graphContainerRef = useRef<HTMLDivElement>(null);
   const prevLoadingRef = useRef(loading);
 
   const nodeTypes = useMemo(() => ({ appNode: AppNode, groupNode: GroupNode }), []);
@@ -81,15 +81,22 @@ export function DependencyGraph() {
   useEffect(() => {
     const wasLoading = prevLoadingRef.current;
     prevLoadingRef.current = loading;
+    const graphContainer = graphContainerRef.current;
+
+    if (!graphContainer) {
+      return;
+    }
 
     if (loading || nodes.length === 0) {
-      setInteractionReady(false);
+      graphContainer.dataset.interactionReady = 'false';
       return;
     }
 
     if (!wasLoading) {
       return;
     }
+
+    graphContainer.dataset.interactionReady = 'false';
 
     let cancelled = false;
     let animationFrame: number | undefined;
@@ -98,7 +105,7 @@ export function DependencyGraph() {
       animationFrame = window.requestAnimationFrame(() => {
         void fitView({ duration: disableAnimations ? 0 : 400, padding: 0.2 }).then(() => {
           if (!cancelled) {
-            setInteractionReady(true);
+            graphContainer.dataset.interactionReady = 'true';
           }
         });
       });
@@ -223,9 +230,9 @@ export function DependencyGraph() {
 
   return (
     <div
+        ref={graphContainerRef}
         className="absolute inset-0 w-full h-full"
         data-layout-ready={!loading && nodes.length > 0}
-        data-interaction-ready={interactionReady}
     >
       <ReactFlow
         nodes={nodes}

--- a/src/features/visualization/components/DependencyGraph.tsx
+++ b/src/features/visualization/components/DependencyGraph.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useCallback } from 'react';
+import { useEffect, useMemo, useCallback, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { ReactFlow, Background, Controls, MiniMap, useReactFlow, type Node } from '@xyflow/react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -53,6 +53,8 @@ export function DependencyGraph() {
   })));
 
   const { getIntersectingNodes, getInternalNode, getNode, fitView } = useReactFlow();
+  const [interactionReady, setInteractionReady] = useState(false);
+  const prevLoadingRef = useRef(loading);
 
   const nodeTypes = useMemo(() => ({ appNode: AppNode, groupNode: GroupNode }), []);
 
@@ -75,17 +77,40 @@ export function DependencyGraph() {
     setGraphData(parsedData, parsedMetrics);
   }, [setGraphData]);
 
-  // Re-fit view when layout finishes
+  // Re-fit view only when layout finishes, and expose readiness only after fitView completes.
   useEffect(() => {
-    if (!loading && nodes.length > 0) {
-      // Small delay to allow React Flow to render updated positions
-      const t = setTimeout(() => {
-        window.requestAnimationFrame(() => {
-            void fitView({ duration: disableAnimations ? 0 : 400, padding: 0.2 });
-        });
-      }, 250);
-      return () => clearTimeout(t);
+    const wasLoading = prevLoadingRef.current;
+    prevLoadingRef.current = loading;
+
+    if (loading || nodes.length === 0) {
+      setInteractionReady(false);
+      return;
     }
+
+    if (!wasLoading) {
+      return;
+    }
+
+    let cancelled = false;
+    let animationFrame: number | undefined;
+    const delay = disableAnimations ? 0 : 250;
+    const timer = window.setTimeout(() => {
+      animationFrame = window.requestAnimationFrame(() => {
+        void fitView({ duration: disableAnimations ? 0 : 400, padding: 0.2 }).then(() => {
+          if (!cancelled) {
+            setInteractionReady(true);
+          }
+        });
+      });
+    }, delay);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+      if (animationFrame !== undefined) {
+        window.cancelAnimationFrame(animationFrame);
+      }
+    };
   }, [loading, nodes.length, fitView, disableAnimations]);
 
   const onNodeDragStop = useCallback(
@@ -196,11 +221,11 @@ export function DependencyGraph() {
     selectNode(null);
   }, [selectNode]);
 
-  // data-layout-ready is used by E2E tests to verify layout completion
   return (
     <div
         className="absolute inset-0 w-full h-full"
         data-layout-ready={!loading && nodes.length > 0}
+        data-interaction-ready={interactionReady}
     >
       <ReactFlow
         nodes={nodes}
@@ -216,7 +241,7 @@ export function DependencyGraph() {
         minZoom={0.1}
       >
         <Background />
-        <Controls position="bottom-right" />
+        <Controls position="bottom-right" fitViewOptions={disableAnimations ? { duration: 0 } : undefined} />
         <MiniMap
           nodeColor={miniMapNodeColor}
           nodeStrokeColor="transparent"

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -31,10 +31,12 @@ test('App elements are visible', async ({ page }) => {
     const node = page.getByTestId('node-main.tsx');
 
     // Fit view to ensure the node is in the viewport, especially on mobile
-    await page.getByRole('button', { name: 'fit view' }).click();
+    // React Flow's control can keep moving while the mobile viewport settles.
+    // A forced click still exercises the control without waiting on pixel stability.
+    await page.getByRole('button', { name: 'fit view' }).click({ force: true });
 
     await expect(node).toBeVisible();
-    await node.click();
+    await node.click({ force: true });
 
     await expect(page.getByTestId('isolate-module-toggle')).toBeVisible();
   });

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1,7 +1,9 @@
 import { test, expect } from '@playwright/test';
 
 test('App elements are visible', async ({ page }) => {
+  test.setTimeout(120_000);
   await page.goto('/?disableAnimations=true');
+  await expect(page.locator('[data-interaction-ready="true"]')).toBeVisible({ timeout: 75_000 });
 
   await test.step('Verify Header elements', async () => {
     const viewport = page.viewportSize();
@@ -26,17 +28,10 @@ test('App elements are visible', async ({ page }) => {
   await test.step('Verify GraphOverlay controls', async () => {
     await expect(page.getByTestId('refactor-graph-btn')).toBeVisible();
 
-    // Select a node to make the isolate module toggle visible
-    // We use main.tsx as it is known to be visible in the viewport across devices (verified in node_visibility.spec.ts)
+    // Select a node only after the graph layout and post-layout fitView are complete.
     const node = page.getByTestId('node-main.tsx');
-
-    // Fit view to ensure the node is in the viewport, especially on mobile
-    // React Flow's control can keep moving while the mobile viewport settles.
-    // A forced click still exercises the control without waiting on pixel stability.
-    await page.getByRole('button', { name: 'fit view' }).click({ force: true });
-
     await expect(node).toBeVisible();
-    await node.click({ force: true });
+    await node.click();
 
     await expect(page.getByTestId('isolate-module-toggle')).toBeVisible();
   });

--- a/tests/e2e/node_visibility.spec.ts
+++ b/tests/e2e/node_visibility.spec.ts
@@ -8,13 +8,15 @@ test('File nodes are visible and interactable (not obscured by folders)', async 
   const node = page.getByTestId('node-main.tsx');
 
   // Fit view to ensure the node is in the viewport, especially on mobile
-  await page.getByRole('button', { name: 'fit view' }).click();
+  // React Flow's control can keep moving while the mobile viewport settles.
+  await page.getByRole('button', { name: 'fit view' }).click({ force: true });
 
   // 1. Verify it is visible in the viewport/DOM
   await expect(node).toBeVisible();
 
-  // 2. Verify it is not obscured by other elements (like folder nodes)
-  // The 'click' action with trial: true performs actionable checks without clicking.
-  // This ensures the center of the element is visible to the user and not covered.
-  await node.click({ trial: true });
+  // 2. Exercise the node and verify the click reached its handler. A trial click
+  // waits for pixel stability, which React Flow cannot guarantee while WebKit
+  // is settling a mobile viewport.
+  await node.click({ force: true });
+  await expect(page.getByTestId('isolate-module-toggle')).toBeVisible();
 });

--- a/tests/e2e/node_visibility.spec.ts
+++ b/tests/e2e/node_visibility.spec.ts
@@ -1,22 +1,16 @@
 import { test, expect } from '@playwright/test';
 
 test('File nodes are visible and interactable (not obscured by folders)', async ({ page }) => {
+  test.setTimeout(120_000);
   await page.goto('/?disableAnimations=true');
+  await expect(page.locator('[data-interaction-ready="true"]')).toBeVisible({ timeout: 75_000 });
 
-  // Wait for the graph to load and render nodes.
-  // We look for a specific file node that we know exists in the sample data (e.g., main.tsx).
   const node = page.getByTestId('node-main.tsx');
 
-  // Fit view to ensure the node is in the viewport, especially on mobile
-  // React Flow's control can keep moving while the mobile viewport settles.
-  await page.getByRole('button', { name: 'fit view' }).click({ force: true });
-
-  // 1. Verify it is visible in the viewport/DOM
+  // Verify the node is visible and that Playwright can hit-test it normally.
+  // This deliberately preserves the regression protection against folder/overlay obstruction.
   await expect(node).toBeVisible();
-
-  // 2. Exercise the node and verify the click reached its handler. A trial click
-  // waits for pixel stability, which React Flow cannot guarantee while WebKit
-  // is settling a mobile viewport.
-  await node.click({ force: true });
+  await node.click({ trial: true });
+  await node.click();
   await expect(page.getByTestId('isolate-module-toggle')).toBeVisible();
 });

--- a/tests/e2e/simulation_state.spec.ts
+++ b/tests/e2e/simulation_state.spec.ts
@@ -15,10 +15,15 @@ test.describe('Simulation State', () => {
     // Fit view to ensure nodes are within viewport for consistent coordinates
     const fitViewBtn = page.getByRole('button', { name: 'fit view' });
     await expect(fitViewBtn).toBeVisible();
-    await fitViewBtn.click();
+    await fitViewBtn.click({ force: true });
   });
 
-  test('dragging a node into a new folder should update its fullPath in the simulation state', async ({ page }) => {
+  test('dragging a node into a new folder should update its fullPath in the simulation state', async ({ page }, testInfo) => {
+    test.skip(
+      testInfo.project.name === 'Mobile Safari',
+      'Playwright cannot synthesize the touch drag gesture used by React Flow on iPad.',
+    );
+
     const targetNode = page.getByTestId(APP_TSX_TEST_ID);
     const targetGroup = page.getByTestId(FEATURES_GROUP_TEST_ID);
 

--- a/tests/e2e/simulation_state.spec.ts
+++ b/tests/e2e/simulation_state.spec.ts
@@ -5,25 +5,12 @@ test.describe('Simulation State', () => {
   const FEATURES_GROUP_TEST_ID = 'node-features';
 
   test.beforeEach(async ({ page }) => {
-    // Navigate to the app with animations disabled
-    await page.goto('http://localhost:5173/dependency-maritime/?disableAnimations=true');
-    // Wait for canvas to be present
-    await page.waitForSelector('.react-flow__renderer');
-    // Wait for at least one node to render
-    await page.waitForSelector('.react-flow__node');
-
-    // Fit view to ensure nodes are within viewport for consistent coordinates
-    const fitViewBtn = page.getByRole('button', { name: 'fit view' });
-    await expect(fitViewBtn).toBeVisible();
-    await fitViewBtn.click({ force: true });
+    test.setTimeout(120_000);
+    await page.goto('/?disableAnimations=true');
+    await expect(page.locator('[data-interaction-ready="true"]')).toBeVisible({ timeout: 75_000 });
   });
 
-  test('dragging a node into a new folder should update its fullPath in the simulation state', async ({ page }, testInfo) => {
-    test.skip(
-      testInfo.project.name === 'Mobile Safari',
-      'Playwright cannot synthesize the touch drag gesture used by React Flow on iPad.',
-    );
-
+  test('dragging a node into a new folder should update its fullPath in the simulation state', async ({ page }) => {
     const targetNode = page.getByTestId(APP_TSX_TEST_ID);
     const targetGroup = page.getByTestId(FEATURES_GROUP_TEST_ID);
 
@@ -31,20 +18,16 @@ test.describe('Simulation State', () => {
     await expect(targetGroup).toBeVisible();
 
     // 1. Verify Initial State
-    // Click to select the node
     await targetNode.click();
 
-    // Check Overlay for initial path
     const overlayPath = page.locator('.absolute.inset-0').getByText('src/App.tsx');
     await expect(overlayPath).toBeVisible();
 
-    // Close Inspector if open to prevent obstruction later
-    // Check if it's the toggle button in the top bar.
-    // To close the panel, we might need to click the "Close" button inside the panel if it exists, or toggle the top button.
-    // The error showed "Close Inspector" button exists.
+    // Close Inspector if open so it cannot obstruct the drag target.
     const closeInspectorBtn = page.getByRole('button', { name: 'Close Inspector' });
     if (await closeInspectorBtn.isVisible()) {
-        await closeInspectorBtn.click();
+      await closeInspectorBtn.click();
+      await expect(closeInspectorBtn).toBeHidden();
     }
 
     // 2. Perform Drag
@@ -55,31 +38,23 @@ test.describe('Simulation State', () => {
     expect(groupDestBox).not.toBeNull();
 
     if (startBox && groupDestBox) {
-        // Calculate a safe drop position that is inside the group
-        const dropX = groupDestBox.x + 50;
-        const dropY = groupDestBox.y + 50;
+      const viewport = page.viewportSize();
+      const rawDropX = groupDestBox.x + Math.min(50, groupDestBox.width / 2);
+      const rawDropY = groupDestBox.y + Math.min(50, groupDestBox.height / 2);
+      const dropX = viewport ? Math.min(Math.max(rawDropX, 1), viewport.width - 1) : rawDropX;
+      const dropY = viewport ? Math.min(Math.max(rawDropY, 1), viewport.height - 1) : rawDropY;
 
-        await page.mouse.move(startBox.x + startBox.width / 2, startBox.y + startBox.height / 2);
-        await page.mouse.down();
-        // Move in steps to simulate drag
-        await page.mouse.move(dropX, dropY, { steps: 20 });
-        await page.mouse.up();
+      await page.mouse.move(startBox.x + startBox.width / 2, startBox.y + startBox.height / 2);
+      await page.mouse.down();
+      await page.mouse.move(dropX, dropY, { steps: 20 });
+      await page.mouse.up();
     }
 
     // 3. Verify Updated State
-    // Ensure node is still selected or re-select it
-    // If the drag worked, the node moved.
-    // If we can't click it easily, we can assume it's still selected if we didn't click elsewhere.
-
-    // Check Overlay for NEW path
-    // We accept any path starting with src/features because drag might drop into a subfolder
     const overlayPathLocator = page.locator('.absolute.inset-0 h3 + p');
-
-    // Wait for update
     await expect(overlayPathLocator).not.toHaveText('src/App.tsx', { timeout: 10000 });
 
     const text = await overlayPathLocator.textContent();
-
     expect(text).toContain('src/features/');
     expect(text).toContain('App.tsx');
   });

--- a/tests/e2e/upload-modal.spec.ts
+++ b/tests/e2e/upload-modal.spec.ts
@@ -9,7 +9,7 @@ test('verify upload modal functionality', async ({ page }) => {
   // The button has aria-label="Upload/Select Data Source"
   const uploadBtn = page.getByLabel("Upload/Select Data Source");
   await expect(uploadBtn).toBeVisible();
-  await uploadBtn.click();
+  await uploadBtn.click({ force: true });
 
   // Verify modal is open
   const modalTitle = page.getByRole("heading", { name: "Select Data Source" });
@@ -22,7 +22,7 @@ test('verify upload modal functionality', async ({ page }) => {
 
   // Click 'Project Graph'
   const projectGraphBtn = page.getByText("Project Graph");
-  await projectGraphBtn.click();
+  await projectGraphBtn.click({ force: true });
 
   // Modal should close
   await expect(modalTitle).not.toBeVisible();

--- a/tests/e2e/upload-modal.spec.ts
+++ b/tests/e2e/upload-modal.spec.ts
@@ -3,33 +3,29 @@ import { test, expect } from '@playwright/test';
 test('verify upload modal functionality', async ({ page }) => {
   // Navigate to the app
   await page.goto('/?disableAnimations=true');
-  // await page.waitForLoadState('networkidle');
 
-  // Click the upload button
-  // The button has aria-label="Upload/Select Data Source"
-  const uploadBtn = page.getByLabel("Upload/Select Data Source");
+  // Click the upload button through normal Playwright actionability checks.
+  const uploadBtn = page.getByLabel('Upload/Select Data Source');
   await expect(uploadBtn).toBeVisible();
-  await uploadBtn.click({ force: true });
+  await uploadBtn.click();
 
   // Verify modal is open
-  const modalTitle = page.getByRole("heading", { name: "Select Data Source" });
+  const modalTitle = page.getByRole('heading', { name: 'Select Data Source' });
   await expect(modalTitle).toBeVisible();
 
   // Check for options
-  await expect(page.getByText("Sample Data")).toBeVisible();
-  await expect(page.getByText("Project Graph")).toBeVisible();
-  await expect(page.getByText("Click to upload or drag and drop")).toBeVisible();
+  await expect(page.getByText('Sample Data')).toBeVisible();
+  await expect(page.getByText('Project Graph')).toBeVisible();
+  await expect(page.getByText('Click to upload or drag and drop')).toBeVisible();
 
   // Click 'Project Graph'
-  const projectGraphBtn = page.getByText("Project Graph");
-  await projectGraphBtn.click({ force: true });
+  const projectGraphBtn = page.getByText('Project Graph');
+  await projectGraphBtn.click();
 
   // Modal should close
   await expect(modalTitle).not.toBeVisible();
 
-  // Ensure graph is visible (check for a known node from the project graph if possible,
-  // or just that the graph container exists and isn't empty)
-  // For now, we just ensure no crash.
+  // Ensure graph is visible after changing the source.
   const graphContainer = page.locator('.react-flow');
   await expect(graphContainer).toBeVisible();
 });


### PR DESCRIPTION
### Motivation
- Fix #239 at the application readiness boundary instead of bypassing Playwright actionability checks.
- Keep the Mobile Safari simulation path covered rather than skipping the exact interaction that exposed the regression.
- Keep documentation screenshot generation separate from the browser-compatibility suite so the three canonical README screenshots are generated only by the dedicated screenshot configuration.

### What changed
- Folded the substantive #241 graph-stability work into this PR.
- Added an explicit post-layout interaction readiness contract: the graph exposes `data-interaction-ready="true"` only after layout completes and the post-layout `fitView()` promise resolves.
- Refit is gated on the `loading: true -> false` transition so viewport fitting is not repeatedly retriggered by ordinary renders.
- Disabled React Flow control animation duration when `disableAnimations=true`.
- Updated `app.spec.ts`, `node_visibility.spec.ts`, and `simulation_state.spec.ts` to wait for interaction readiness instead of manually forcing fit-view clicks.
- Restored normal Playwright clicks so hit-target/actionability regressions remain visible.
- Restored the node visibility test's explicit obstruction protection via a trial click before the real click.
- Removed the Mobile Safari skip from the simulation-state drag test; the fullPath reparenting assertion remains covered on every configured project.
- Corrected node-selection behavior so the inspector auto-opens only for desktop-style fine-pointer devices, rather than treating wide touch tablets such as iPad as desktop solely because they exceed the 768px breakpoint.
- Restored normal actionability-checked clicks in `upload-modal.spec.ts`; its forced clicks were unrelated to the graph readiness issue.
- Excluded `generate-screenshots.spec.ts` from the default E2E matrix. Documentation screenshots remain generated by `test:screenshots` with the dedicated single-Chromium screenshot config.
- Removed the broad 60-second Playwright default timeout increase; the graph-heavy tests use targeted timeouts while synchronizing against explicit readiness.

### Why this approach
`data-layout-ready` becomes true as soon as layout data is available, but the post-layout viewport fit can still be pending. Releasing tests at that point explains why forced clicks appeared necessary. Waiting until `fitView()` completes gives tests a deterministic interaction boundary without fixed sleeps or actionability bypasses.

The remaining Mobile Safari failure exposed a separate UI classification bug: the iPad profile is 810px wide, so the previous width-only `>= 768px` check incorrectly auto-opened the desktop inspector on a touch-first device. That panel then covered the drag surface. Desktop auto-open behavior should require both desktop width and a fine pointer.

### Acceptance coverage
- No `waitForTimeout` added for graph synchronization.
- Mobile Safari simulation test remains enabled.
- Node clicks use normal actionability checks.
- Touch-first tablets do not auto-open the desktop inspector when selecting a node.
- Reparenting still verifies the simulated node's `fullPath` moves under `src/features/`.
- Documentation screenshots remain independently generated and are no longer multiplied across the browser compatibility matrix.

Fixes #239